### PR TITLE
Get the resolver back from `Wesl<R: Resolver>`

### DIFF
--- a/crates/wesl/src/lib.rs
+++ b/crates/wesl/src/lib.rs
@@ -550,6 +550,11 @@ impl<R: Resolver> Wesl<R> {
         self.options.keep = None;
         self
     }
+
+    /// Get a reference to the current [`Resolver`].
+    pub fn resolver(&self) -> &R {
+        &self.resolver
+    }
 }
 
 /// The result of [`Wesl::compile`].


### PR DESCRIPTION
Add a method to get access to the resolver from an wesl instance. I need this (or some equivalent) in https://github.com/jannik4/wesldoc/commit/8de1dfe864b8e43414a319f890de871cc3944916 to support auto depencies, since the resolver collects the dependencies on the fly.