### PR TITLE
Fix tests on systems with git < 2.49.0

### DIFF
--- a/crates/wesl-test/tests/testsuite.rs
+++ b/crates/wesl-test/tests/testsuite.rs
@@ -4,7 +4,7 @@
 //! These tests are run with `harness = false` in `Cargo.toml`, because they rely on the
 //! `libtest_mimic` custom harness to generate tests at runtime based on the JSON files.
 
-use std::{cmp::Ordering, ffi::OsStr, path::PathBuf, process::Command, str::FromStr};
+use std::{ffi::OsStr, path::PathBuf, process::Command, str::FromStr};
 
 use wesl::{
     CompileOptions, EscapeMangler, NoMangler, SyntaxUtil, VirtualResolver, syntax::*, validate_wesl,
@@ -201,97 +201,6 @@ fn main() {
     libtest_mimic::run(&args, tests).exit();
 }
 
-fn git_version_at_least(version: [u8; 3]) -> bool {
-    // Modeled after https://github.com/gfx-rs/wgpu/blob/c0a580d6f0343a725b3defa8be4fdf0a9691eaad/xtask/src/cts.rs#L130
-    let output = Command::new("git")
-        .arg("--version")
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .expect("failed to execute git --version")
-        .wait_with_output()
-        .expect("failed to wait on git");
-
-    let Some(code) = output.status.code() else {
-        panic!("`git --version` failed to return an exit code; interrupt via signal, maybe?")
-    };
-
-    assert_eq!(code, 0, "`git --version` returned a nonzero exit code");
-
-    let output = String::from_utf8(output.stdout)
-        .expect("`git --version` did not have the expected structure");
-
-    let parsed = parse_git_version_output(&output);
-    let expected = GitVersion::new(version);
-    parsed >= expected
-}
-
-#[derive(PartialEq, Eq)]
-pub struct GitVersion {
-    major: u8,
-    minor: u8,
-    patch: u8,
-}
-
-impl GitVersion {
-    pub fn new(parts: [u8; 3]) -> Self {
-        GitVersion {
-            major: parts[0],
-            minor: parts[1],
-            patch: parts[2],
-        }
-    }
-}
-
-impl PartialOrd for GitVersion {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for GitVersion {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.major
-            .cmp(&other.major)
-            .then(self.minor.cmp(&other.minor))
-            .then(self.patch.cmp(&other.patch))
-    }
-}
-
-fn parse_git_version_output(output: &str) -> GitVersion {
-    // Modeled after https://github.com/gfx-rs/wgpu/blob/c0a580d6f0343a725b3defa8be4fdf0a9691eaad/xtask/src/cts.rs#L154
-    const PREFIX: &str = "git version ";
-
-    let raw_version = output.strip_prefix(PREFIX).unwrap();
-
-    // There should always be a newline at the end, but we don't care if it's missing.
-    let raw_version = raw_version.trim();
-
-    // Git for Windows suffixes the version with ".windows.<n>". Strip it if present.
-    let raw_version = raw_version
-        .split_once(".windows")
-        .map_or(raw_version, |(before, _after)| before);
-
-    // Git for macOS suffixes the version number with " (Apple Git-<n>)". Strip it if present.
-    let raw_version = raw_version
-        .split_once(" ")
-        .map_or(raw_version, |(before, _after)| before);
-
-    let [major, minor, patch] = <[u8; 3]>::try_from(
-        raw_version
-            .splitn(3, '.')
-            .map(|s| s.parse().expect("failed to parse version number"))
-            .collect::<Vec<_>>(),
-    )
-    .expect("less than 3 version numbers found");
-
-    GitVersion {
-        major,
-        minor,
-        patch,
-    }
-}
-
 fn fetch_bulk_test(bulk_test: &WgslBulkTest, cwd: &std::path::Path) -> std::io::Result<()> {
     // Modeled after https://github.com/gfx-rs/wgpu/blob/c0a580d6f0343a725b3defa8be4fdf0a9691eaad/xtask/src/cts.rs
     let Some(WgslGitSrc { url, revision }) = &bulk_test.git else {
@@ -340,76 +249,53 @@ fn fetch_bulk_test(bulk_test: &WgslBulkTest, cwd: &std::path::Path) -> std::io::
             panic!("Git checkout failed");
         }
     } else {
-        // The --revision flag is not supported by git versions below 2.49.0
-        if git_version_at_least([2, 49, 0]) {
-            let git_clone = Command::new("git")
-                .args([
-                    "clone",
-                    "--depth=1",
-                    url,
-                    "--revision",
-                    revision,
-                    &bulk_test.base_dir,
-                ])
-                .current_dir(cwd)
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::inherit())
-                .spawn()
-                .expect("failed to execute git clone")
-                .wait()
-                .expect("failed to wait on git");
+        // Note: The --revision flag is not supported by git versions below 2.49.0 (so we don't use it)
+        let git_clone = Command::new("git")
+            .args([
+                "clone",
+                url,
+                "--no-checkout",
+                "--depth",
+                "1",
+                &bulk_test.base_dir,
+            ])
+            .current_dir(cwd)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::inherit())
+            .spawn()
+            .expect("failed to execute git clone")
+            .wait()
+            .expect("failed to wait on git");
 
-            if !git_clone.success() {
-                panic!("Git clone failed");
-            }
-        } else {
-            let git_clone = Command::new("git")
-                .args([
-                    "clone",
-                    url,
-                    "--no-checkout",
-                    "--depth",
-                    "1",
-                    &bulk_test.base_dir,
-                ])
-                .current_dir(cwd)
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::inherit())
-                .spawn()
-                .expect("failed to execute git clone")
-                .wait()
-                .expect("failed to wait on git");
+        if !git_clone.success() {
+            panic!("Git clone failed");
+        }
 
-            if !git_clone.success() {
-                panic!("Git clone failed");
-            }
+        let git_fetch = Command::new("git")
+            .args(["fetch", "--quiet", "--depth", "1", "origin", revision])
+            .current_dir(&base_dir)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::inherit())
+            .spawn()
+            .expect("failed to execute git fetch")
+            .wait()
+            .expect("failed to wait on git");
+        if !git_fetch.success() {
+            panic!("Git fetch failed");
+        }
 
-            let git_fetch = Command::new("git")
-                .args(["fetch", "--quiet", "--depth", "1", "origin", revision])
-                .current_dir(&base_dir)
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::inherit())
-                .spawn()
-                .expect("failed to execute git fetch")
-                .wait()
-                .expect("failed to wait on git");
-            if !git_fetch.success() {
-                panic!("Git fetch failed");
-            }
+        let git_checkout = Command::new("git")
+            .args(["checkout", "--quiet", revision])
+            .current_dir(&base_dir)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::inherit())
+            .spawn()
+            .expect("failed to execute git checkout")
+            .wait()
+            .expect("failed to wait on git");
 
-            let git_checkout = Command::new("git")
-                .args(["checkout", "--quiet", revision])
-                .current_dir(&base_dir)
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::inherit())
-                .spawn()
-                .expect("failed to execute git checkout")
-                .wait()
-                .expect("failed to wait on git");
-
-            if !git_checkout.success() {
-                panic!("Git checkout {:?} failed", revision);
-            }
+        if !git_checkout.success() {
+            panic!("Git checkout {:?} failed", revision);
         }
     }
 


### PR DESCRIPTION
I'm on MacOS Sequoia 15.6.1 with a git version of `2.39.5 (Apple Git-154)`. I was unable to run the test suite because a git clone was failing with:
```
error: unknown option `revision'
```

~~This PR adopts the [wgpu's workaround](https://github.com/gfx-rs/wgpu/blob/c0a580d6f0343a725b3defa8be4fdf0a9691eaad/xtask/src/cts.rs#L61) for git < 2.49.0.~~