### PR TITLE
Add support for the WGSL `barycentric` builtin to `wgsl-types`

### DIFF
--- a/crates/wesl-test/wgpu/in/barycentrics.wgsl
+++ b/crates/wesl-test/wgpu/in/barycentrics.wgsl
@@ -2,3 +2,8 @@
 fn fs_main(@builtin(barycentric) bary: vec3<f32>) -> @location(0) vec4<f32> {
     return vec4(bary, 1.0);
 }
+
+@fragment
+fn fs_main_no_perspective(@builtin(barycentric_no_perspective) bary: vec3<f32>) -> @location(0) vec4<f32> {
+    return vec4(bary, 1.0);
+}

--- a/crates/wesl-test/wgpu/in/barycentrics.wgsl
+++ b/crates/wesl-test/wgpu/in/barycentrics.wgsl
@@ -1,0 +1,4 @@
+@fragment
+fn fs_main(@builtin(barycentric) bary: vec3<f32>) -> @location(0) vec4<f32> {
+    return vec4(bary, 1.0);
+}

--- a/crates/wesl/Cargo.toml
+++ b/crates/wesl/Cargo.toml
@@ -44,7 +44,7 @@ generics = ["wgsl-parse/generics"]
 #
 # List of supported naga extensions:
 # * 64-bit types: i64/u64/f64 and li, lu, lf literal suffixes
-# * extra builtins: `subgroup_id`, `num_subgroups`, `primitive_index`, `view_index`
+# * extra builtins: `subgroup_id`, `num_subgroups`, `primitive_index`, `barycentric`, `view_index`
 # * extra texel formats: see `TexelFormat`
 # * `immediate` address space
 # * `atomic` access mode for textures

--- a/crates/wesl/Cargo.toml
+++ b/crates/wesl/Cargo.toml
@@ -44,7 +44,7 @@ generics = ["wgsl-parse/generics"]
 #
 # List of supported naga extensions:
 # * 64-bit types: i64/u64/f64 and li, lu, lf literal suffixes
-# * extra builtins: `subgroup_id`, `num_subgroups`, `primitive_index`, `barycentric`, `view_index`
+# * extra builtins: `subgroup_id`, `num_subgroups`, `primitive_index`, `barycentric`, `barycentric_no_perspective`, `view_index`
 # * extra texel formats: see `TexelFormat`
 # * `immediate` address space
 # * `atomic` access mode for textures

--- a/crates/wesl/src/eval/exec.rs
+++ b/crates/wesl/src/eval/exec.rs
@@ -757,6 +757,8 @@ pub struct Inputs {
     #[cfg(feature = "naga-ext")]
     pub barycentric: Option<[f32; 3]>,
     #[cfg(feature = "naga-ext")]
+    pub barycentric_no_perspective: Option<[f32; 3]>,
+    #[cfg(feature = "naga-ext")]
     pub view_index: Option<u32>,
 
     pub user_defined: HashMap<u32, Instance>,
@@ -786,6 +788,8 @@ impl Inputs {
             primitive_index: Some(0),
             #[cfg(feature = "naga-ext")]
             barycentric: Some([0.0, 0.0, 0.0]),
+            #[cfg(feature = "naga-ext")]
+            barycentric_no_perspective: Some([0.0, 0.0, 0.0]),
             #[cfg(feature = "naga-ext")]
             view_index: Some(0),
             user_defined: Default::default(),
@@ -853,6 +857,10 @@ pub fn exec_entrypoint(
                     BuiltinValue::Barycentric => {
                         inputs.barycentric.map(|v| VecInstance::from(v).into())
                     }
+                    #[cfg(feature = "naga-ext")]
+                    BuiltinValue::BarycentricNoPerspective => inputs
+                        .barycentric_no_perspective
+                        .map(|v| VecInstance::from(v).into()),
                     #[cfg(feature = "naga-ext")]
                     BuiltinValue::ViewIndex => inputs.view_index.map(Instance::from),
                     BuiltinValue::ClipDistances | BuiltinValue::FragDepth => {

--- a/crates/wesl/src/eval/exec.rs
+++ b/crates/wesl/src/eval/exec.rs
@@ -755,6 +755,8 @@ pub struct Inputs {
     #[cfg(feature = "naga-ext")]
     pub primitive_index: Option<u32>,
     #[cfg(feature = "naga-ext")]
+    pub barycentric: Option<[f32; 3]>,
+    #[cfg(feature = "naga-ext")]
     pub view_index: Option<u32>,
 
     pub user_defined: HashMap<u32, Instance>,
@@ -782,6 +784,8 @@ impl Inputs {
             num_subgroups: Some(1),
             #[cfg(feature = "naga-ext")]
             primitive_index: Some(0),
+            #[cfg(feature = "naga-ext")]
+            barycentric: Some([0.0, 0.0, 0.0]),
             #[cfg(feature = "naga-ext")]
             view_index: Some(0),
             user_defined: Default::default(),
@@ -816,27 +820,25 @@ pub fn exec_entrypoint(
                 match builtin {
                     BuiltinValue::VertexIndex => inputs.vertex_index.map(Instance::from),
                     BuiltinValue::InstanceIndex => inputs.instance_index.map(Instance::from),
-                    BuiltinValue::Position => {
-                        inputs.position.map(|pos| VecInstance::from(pos).into())
-                    }
+                    BuiltinValue::Position => inputs.position.map(|v| VecInstance::from(v).into()),
                     BuiltinValue::FrontFacing => inputs.front_facing.map(Instance::from),
                     BuiltinValue::SampleIndex => inputs.sample_index.map(Instance::from),
                     BuiltinValue::SampleMask => inputs.sample_mask.map(Instance::from),
                     BuiltinValue::LocalInvocationId => inputs
                         .local_invocation_id
-                        .map(|pos| VecInstance::from(pos).into()),
+                        .map(|v| VecInstance::from(v).into()),
                     BuiltinValue::LocalInvocationIndex => {
                         inputs.local_invocation_index.map(Instance::from)
                     }
                     BuiltinValue::GlobalInvocationId => inputs
                         .global_invocation_id
-                        .map(|pos| VecInstance::from(pos).into()),
+                        .map(|v| VecInstance::from(v).into()),
                     BuiltinValue::WorkgroupId => {
-                        inputs.workgroup_id.map(|pos| VecInstance::from(pos).into())
+                        inputs.workgroup_id.map(|v| VecInstance::from(v).into())
                     }
-                    BuiltinValue::NumWorkgroups => inputs
-                        .num_workgroups
-                        .map(|pos| VecInstance::from(pos).into()),
+                    BuiltinValue::NumWorkgroups => {
+                        inputs.num_workgroups.map(|v| VecInstance::from(v).into())
+                    }
                     BuiltinValue::SubgroupInvocationId => {
                         inputs.subgroup_invocation_id.map(Instance::from)
                     }
@@ -847,6 +849,10 @@ pub fn exec_entrypoint(
                     BuiltinValue::NumSubgroups => inputs.num_subgroups.map(Instance::from),
                     #[cfg(feature = "naga-ext")]
                     BuiltinValue::PrimitiveIndex => inputs.primitive_index.map(Instance::from),
+                    #[cfg(feature = "naga-ext")]
+                    BuiltinValue::Barycentric => {
+                        inputs.barycentric.map(|v| VecInstance::from(v).into())
+                    }
                     #[cfg(feature = "naga-ext")]
                     BuiltinValue::ViewIndex => inputs.view_index.map(Instance::from),
                     BuiltinValue::ClipDistances | BuiltinValue::FragDepth => {

--- a/crates/wgsl-types/src/syntax.rs
+++ b/crates/wgsl-types/src/syntax.rs
@@ -206,7 +206,11 @@ pub enum BuiltinValue {
     #[cfg(feature = "naga-ext")]
     PrimitiveIndex,
     #[cfg(feature = "naga-ext")]
-    Barycentric, /// requires WGSL extension barycentric
+    Barycentric,
+    /// requires WGSL extension barycentric
+    #[cfg(feature = "naga-ext")]
+    BarycentricNoPerspective,
+    /// requires WGSL extension barycentric
     #[cfg(feature = "naga-ext")]
     ViewIndex,
 }
@@ -694,6 +698,8 @@ impl FromStr for BuiltinValue {
             #[cfg(feature = "naga-ext")]
             "barycentric" => Ok(Self::Barycentric),
             #[cfg(feature = "naga-ext")]
+            "barycentric_no_perspective" => Ok(Self::BarycentricNoPerspective),
+            #[cfg(feature = "naga-ext")]
             "view_index" => Ok(Self::ViewIndex),
             _ => Err(()),
         }
@@ -893,6 +899,8 @@ impl Display for BuiltinValue {
             Self::PrimitiveIndex => write!(f, "primitive_index"),
             #[cfg(feature = "naga-ext")]
             Self::Barycentric => write!(f, "barycentric"),
+            #[cfg(feature = "naga-ext")]
+            Self::BarycentricNoPerspective => write!(f, "barycentric_no_perspective"),
             #[cfg(feature = "naga-ext")]
             Self::ViewIndex => write!(f, "view_index"),
         }

--- a/crates/wgsl-types/src/syntax.rs
+++ b/crates/wgsl-types/src/syntax.rs
@@ -206,6 +206,8 @@ pub enum BuiltinValue {
     #[cfg(feature = "naga-ext")]
     PrimitiveIndex,
     #[cfg(feature = "naga-ext")]
+    Barycentric, /// requires WGSL extension barycentric
+    #[cfg(feature = "naga-ext")]
     ViewIndex,
 }
 
@@ -690,6 +692,8 @@ impl FromStr for BuiltinValue {
             #[cfg(feature = "naga-ext")]
             "primitive_index" => Ok(Self::PrimitiveIndex),
             #[cfg(feature = "naga-ext")]
+            "barycentric" => Ok(Self::Barycentric),
+            #[cfg(feature = "naga-ext")]
             "view_index" => Ok(Self::ViewIndex),
             _ => Err(()),
         }
@@ -887,6 +891,8 @@ impl Display for BuiltinValue {
             Self::NumSubgroups => write!(f, "num_subgroups"),
             #[cfg(feature = "naga-ext")]
             Self::PrimitiveIndex => write!(f, "primitive_index"),
+            #[cfg(feature = "naga-ext")]
+            Self::Barycentric => write!(f, "barycentric"),
             #[cfg(feature = "naga-ext")]
             Self::ViewIndex => write!(f, "view_index"),
         }


### PR DESCRIPTION
Add support for the WGSL `barycentric` builtin to `wgsl-types`.

`wgpu` exposes `SHADER_BARYCENTRICS`, but the `wesl`/`wgsl-types` rejects shaders that use `@builtin(barycentric)` because `wgsl-types` doesn’t recognize that builtin yet. This change makes `wgsl-types` compatible with barycentric support in modern GPUs.
