### PR TITLE
Pin docker image for GitHub release action

### DIFF
--- a/.github/actions/github-release/Dockerfile
+++ b/.github/actions/github-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim
+FROM node:24.16-slim@sha256:ca520832af80fa37a57c14077ed0fcdd83b5aefccc356059fdc3a9a05b78ae1f
 
 COPY . /action
 WORKDIR /action


### PR DESCRIPTION
Avoids a regression in 24.17