### PR TITLE
update Rust and fix Cargo.toml formatting error in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ env:
   CARGO_TERM_COLOR: always
   # If nightly is breaking CI, modify this variable to target a specific nightly version.
   NIGHTLY_TOOLCHAIN: nightly
-  STABLE_TOOLCHAIN: "1.87.0"
+  STABLE_TOOLCHAIN: "1.96.0"
   MIRIFLAGS: "-Zmiri-disable-isolation"
 
 concurrency:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -27,3 +27,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          rust-version: "1.96.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ default-members = [
 [workspace.package]
 version = "0.4.0"
 edition = "2024"
-rust-version = "1.87.0"
+rust-version = "1.96.0"
 repository = "https://github.com/wgsl-tooling-wg/wesl-rs"
 license = "MIT OR Apache-2.0"
 

--- a/crates/wesl-quote/Cargo.toml
+++ b/crates/wesl-quote/Cargo.toml
@@ -20,7 +20,9 @@ token_stream_flatten = { version = "0.1.0" }
 wgsl-parse = { workspace = true, features = ["tokrepr", "wesl"] }
 
 [dev-dependencies]
-wesl = { path = "../wesl" }  # for unit tests. We can't use { workspace = true } because of a dependency cycle. see Cargo#4242.
+wesl = {
+  path = "../wesl"
+}  # for unit tests. We can't use { workspace = true } because of a dependency cycle. see Cargo#4242.
 
 [lints]
 workspace = true

--- a/crates/wesl-quote/src/quote_macro.rs
+++ b/crates/wesl-quote/src/quote_macro.rs
@@ -54,10 +54,10 @@ fn maybe_template_end(lex: &mut Lexer, current: Token, lookahead: Option<Token>)
 // operators && and || have lower precedence than < and >.
 // therefore, this is not a template: a < b || c > d
 fn maybe_fail_template(lex: &mut Lexer) -> bool {
-    if let Some(depth) = lex.extras.template_depths.last() {
-        if lex.extras.depth == *depth {
-            return false;
-        }
+    if let Some(depth) = lex.extras.template_depths.last()
+        && lex.extras.depth == *depth
+    {
+        return false;
     }
     true
 }
@@ -355,17 +355,16 @@ impl Lexer {
 
         let (cur_tok, cur_span) = cur?;
 
-        if let Some((next_tok, offset)) = &mut next {
-            if (matches!(cur_tok, Token::Ident(_)) || cur_tok.is_keyword())
-                && *next_tok == Token::SymLessThan
-            {
-                let input = self.token_stream.clone();
-                if recognize_template_list(input, offset.start) {
-                    *next_tok = Token::TemplateArgsStart;
-                    let cur_depth = self.extras.depth;
-                    self.extras.template_depths.push(cur_depth);
-                    self.opened_templates += 1;
-                }
+        if let Some((next_tok, offset)) = &mut next
+            && (matches!(cur_tok, Token::Ident(_)) || cur_tok.is_keyword())
+            && *next_tok == Token::SymLessThan
+        {
+            let input = self.token_stream.clone();
+            if recognize_template_list(input, offset.start) {
+                *next_tok = Token::TemplateArgsStart;
+                let cur_depth = self.extras.depth;
+                self.extras.template_depths.push(cur_depth);
+                self.opened_templates += 1;
             }
         }
 

--- a/crates/wesl-test/Cargo.toml
+++ b/crates/wesl-test/Cargo.toml
@@ -16,7 +16,10 @@ regex = "1.11.1"
 serde = { version = "1.0.210", features = ["derive"] }
 
 [dev-dependencies]
-bevy-wgsl = { git = "https://github.com/wgsl-tooling-wg/bevy-wgsl", rev = "79f97798c13143947df9b3b1dec5732991557e29" }
+bevy-wgsl = {
+  git = "https://github.com/wgsl-tooling-wg/bevy-wgsl",
+  rev = "79f97798c13143947df9b3b1dec5732991557e29"
+}
 libtest-mimic = "0.8.1"
 serde_json = "1.0.140"
 wesl = { workspace = true, features = ["eval", "naga-ext"] }

--- a/crates/wesl-web/Cargo.toml
+++ b/crates/wesl-web/Cargo.toml
@@ -19,10 +19,14 @@ ansi-to-html = { version = "0.2.3", optional = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 console_log = { version = "1.0.0", features = ["color"], optional = true }
 log = "0.4.22"
-naga = { version = "28.0.0", features = [
-  "wgsl-in",
-  "wgsl-out",
-], optional = true }
+naga = {
+  version = "28.0.0",
+  features = [
+    "wgsl-in",
+    "wgsl-out",
+  ],
+  optional = true
+}
 serde = { version = "1.0.215", features = ["derive"] }
 serde_bytes = "0.11.15"
 serde-wasm-bindgen = "0.6.5"

--- a/crates/wesl/Cargo.toml
+++ b/crates/wesl/Cargo.toml
@@ -13,21 +13,31 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 annotate-snippets = "0.12.4"
-derive_more = { version = "2.0.1", features = [
-  "as_ref",
-  "deref",
-  "deref_mut",
-  "display",
-  "from",
-  "unwrap",
-] }
+derive_more = {
+  version = "2.0.1",
+  features = [
+    "as_ref",
+    "deref",
+    "deref_mut",
+    "display",
+    "from",
+    "unwrap",
+  ]
+}
 glob = { version = "0.3", optional = true }  # dep for feature 'package'
 half = { version = "2.4.1", features = ["num-traits"] }
 itertools = "0.14.0"
 num-traits = "0.2.19"
-proc-macro2 = { version = "1.0.93", optional = true }  # dep for feature 'package'
+proc-macro2 = {
+  version = "1.0.93",
+  optional = true
+}  # dep for feature 'package'
 quote = { version = "1.0.38", optional = true }  # dep for feature 'package'
-serde = { version = "1.0", features = ["derive"], optional = true }  # dep for feature 'package'
+serde = {
+  version = "1.0",
+  features = ["derive"],
+  optional = true
+}  # dep for feature 'package'
 thiserror = "2.0.11"
 toml = { version = "0.9", optional = true }  # dep for feature 'package'
 wesl-macros = { workspace = true, features = ["query"] }

--- a/crates/wesl/src/condcomp.rs
+++ b/crates/wesl/src/condcomp.rs
@@ -229,10 +229,10 @@ fn eval_if_attr_impl(
                 **expr = eval_attr(expr, features)?;
                 has_if = true;
             }
-        } else if let Attribute::Else = attr.node() {
-            if !prev.has_if {
-                return Err(CondCompError::NoPrecedingIf.into());
-            }
+        } else if let Attribute::Else = attr.node()
+            && !prev.has_if
+        {
+            return Err(CondCompError::NoPrecedingIf.into());
         }
         prev.has_if = has_if;
     } else {

--- a/crates/wesl/src/error.rs
+++ b/crates/wesl/src/error.rs
@@ -195,18 +195,18 @@ impl<E: std::error::Error> Diagnostic<E> {
     /// Add metadata collected by the sourcemap. If the mangled declaration name was set,
     /// this will automatically add the source, the module path and the declaration name.
     pub fn with_sourcemap(mut self, sourcemap: &impl SourceMap) -> Self {
-        if let Some(decl) = &self.detail.declaration {
-            if let Some((path, decl)) = sourcemap.get_decl(decl) {
-                self.detail.module_path = Some(path.clone());
-                self.detail.declaration = Some(decl.to_string());
-                self.detail.display_name = sourcemap
-                    .get_display_name(path)
-                    .map(|name| name.to_string());
-                self.detail.source = sourcemap
-                    .get_source(path)
-                    .map(|s| s.to_string())
-                    .or(self.detail.source);
-            }
+        if let Some(decl) = &self.detail.declaration
+            && let Some((path, decl)) = sourcemap.get_decl(decl)
+        {
+            self.detail.module_path = Some(path.clone());
+            self.detail.declaration = Some(decl.to_string());
+            self.detail.display_name = sourcemap
+                .get_display_name(path)
+                .map(|name| name.to_string());
+            self.detail.source = sourcemap
+                .get_source(path)
+                .map(|s| s.to_string())
+                .or(self.detail.source);
         }
 
         if self.detail.source.is_none() {

--- a/crates/wesl/src/eval/constant.rs
+++ b/crates/wesl/src/eval/constant.rs
@@ -31,10 +31,11 @@ pub(crate) fn mark_functions_const(wesl: &mut TranslationUnit) {
         })
         .collect_vec();
     for (decl, is_const) in wesl.global_declarations.iter_mut().zip(is_const) {
-        if let GlobalDeclaration::Function(decl) = decl.node_mut() {
-            if is_const && !decl.contains_attribute(&Attribute::Const) {
-                decl.attributes.push(Attribute::Const.into())
-            }
+        if let GlobalDeclaration::Function(decl) = decl.node_mut()
+            && is_const
+            && !decl.contains_attribute(&Attribute::Const)
+        {
+            decl.attributes.push(Attribute::Const.into())
         }
     }
 }

--- a/crates/wesl/src/generics/mod.rs
+++ b/crates/wesl/src/generics/mod.rs
@@ -102,25 +102,25 @@ pub fn replace_calls(wesl: &mut TranslationUnit) -> Result<(), E> {
         .filter_map(|decl| decl.ident())
         .collect_vec();
     for expr in Visit::<ExpressionNode>::visit_mut(wesl) {
-        if let Expression::FunctionCall(f) = expr.node_mut() {
-            if let Some(args) = &f.ty.template_args {
-                let signature = args
-                    .iter()
-                    .map(|arg| match arg.expression.node() {
-                        Expression::Literal(_) => todo!("literal generics"),
-                        Expression::TypeOrIdentifier(ty) => ty.clone(),
-                        _ => panic!("invalid template arg"),
-                    })
-                    .collect_vec();
+        if let Expression::FunctionCall(f) = expr.node_mut()
+            && let Some(args) = &f.ty.template_args
+        {
+            let signature = args
+                .iter()
+                .map(|arg| match arg.expression.node() {
+                    Expression::Literal(_) => todo!("literal generics"),
+                    Expression::TypeOrIdentifier(ty) => ty.clone(),
+                    _ => panic!("invalid template arg"),
+                })
+                .collect_vec();
 
-                let new_name = mangle::mangle(&f.ty.ident.name(), &signature);
-                f.ty.ident = idents
-                    .iter()
-                    .find(|ident| *ident.name() == new_name)
-                    .unwrap()
-                    .clone();
-                f.ty.template_args = None;
-            }
+            let new_name = mangle::mangle(&f.ty.ident.name(), &signature);
+            f.ty.ident = idents
+                .iter()
+                .find(|ident| *ident.name() == new_name)
+                .unwrap()
+                .clone();
+            f.ty.template_args = None;
         }
         // TODO recursive
         // expr.visit_mut()

--- a/crates/wesl/src/import.rs
+++ b/crates/wesl/src/import.rs
@@ -179,10 +179,10 @@ fn resolve_decl<R: Resolver>(
 ) -> Result<(), Error> {
     if let Some((_, n)) = module.find_decl(ident) {
         let decl = module.source.global_declarations.get(*n).unwrap().node();
-        if let Some(ident) = decl.ident() {
-            if !module.used_idents.borrow_mut().insert(ident) {
-                return Ok(());
-            }
+        if let Some(ident) = decl.ident()
+            && !module.used_idents.borrow_mut().insert(ident)
+        {
+            return Ok(());
         }
 
         for ty in Visit::<TypeExpression>::visit(decl) {
@@ -538,10 +538,10 @@ impl Resolutions {
             for decl in &mut module.source.global_declarations {
                 // we only retarged used declarations. Other declarations are not checked.
                 // unused declarations can even contain invalid code.
-                if let Some(id) = decl.ident() {
-                    if !module.used_idents.borrow().contains(&id) {
-                        continue;
-                    }
+                if let Some(id) = decl.ident()
+                    && !module.used_idents.borrow().contains(&id)
+                {
+                    continue;
                 }
 
                 for ty in Visit::<TypeExpression>::visit_mut(decl.node_mut()) {

--- a/crates/wesl/src/resolve.rs
+++ b/crates/wesl/src/resolve.rs
@@ -525,10 +525,10 @@ impl Resolver for StandardResolver {
         // a special case to handle the constants virtual module. For now, this module
         // is shared for all sub-dependencies.
         // TODO: in the future we'll change that.
-        if let PathOrigin::Package(pkg_name) = &path.origin {
-            if pkg_name == "constants" || pkg_name.ends_with("/constants") {
-                return Ok(self.generate_constant_module().into());
-            }
+        if let PathOrigin::Package(pkg_name) = &path.origin
+            && (pkg_name == "constants" || pkg_name.ends_with("/constants"))
+        {
+            return Ok(self.generate_constant_module().into());
         }
 
         if path.origin.is_package() {

--- a/crates/wesl/src/validate/mod.rs
+++ b/crates/wesl/src/validate/mod.rs
@@ -241,14 +241,13 @@ fn check_cycles(wesl: &TranslationUnit) -> Result<(), Diagnostic<Error>> {
             if res.is_ok() {
                 if ty.ident == *id {
                     res = Err(E::Cycle(id.to_string(), decl.ident().unwrap().to_string()));
-                } else if unique.insert(ty.ident.clone()) {
-                    if let Some(decl) = wesl
+                } else if unique.insert(ty.ident.clone())
+                    && let Some(decl) = wesl
                         .global_declarations
                         .iter()
                         .find(|decl| decl.ident().as_ref() == Some(&ty.ident))
-                    {
-                        res = check_decl(id, decl, unique, wesl);
-                    }
+                {
+                    res = check_decl(id, decl, unique, wesl);
                 }
             }
         });

--- a/crates/wgsl-parse/Cargo.toml
+++ b/crates/wgsl-parse/Cargo.toml
@@ -13,16 +13,19 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 annotate-snippets = "0.12.4"
-derive_more = { version = "2.0.1", features = [
-  "as_ref",
-  "constructor",
-  "deref",
-  "deref_mut",
-  "from",
-  "is_variant",
-  "try_unwrap",
-  "unwrap",
-] }
+derive_more = {
+  version = "2.0.1",
+  features = [
+    "as_ref",
+    "constructor",
+    "deref",
+    "deref_mut",
+    "from",
+    "is_variant",
+    "try_unwrap",
+    "unwrap",
+  ]
+}
 itertools = "0.14.0"
 lalrpop-util = "0.22.1"
 lexical = { version = "7.0.4", features = ["format", "power-of-two"] }

--- a/crates/wgsl-parse/src/lexer.rs
+++ b/crates/wgsl-parse/src/lexer.rs
@@ -39,10 +39,10 @@ fn maybe_template_end(
 // operators && and || have lower precedence than < and >.
 // therefore, this is not a template: a < b || c > d
 fn maybe_fail_template(lex: &mut logos::Lexer<Token>) -> bool {
-    if let Some(depth) = lex.extras.template_depths.last() {
-        if lex.extras.depth == *depth {
-            return false;
-        }
+    if let Some(depth) = lex.extras.template_depths.last()
+        && lex.extras.depth == *depth
+    {
+        return false;
     }
     true
 }
@@ -777,17 +777,16 @@ impl<'s> Lexer<'s> {
             None => return None,
         };
 
-        if let Some((Ok(next_tok), next_span)) = &mut next {
-            if (matches!(cur_tok, Token::Ident(_)) || cur_tok.is_keyword())
-                && *next_tok == Token::SymLessThan
-            {
-                let source = &self.source[next_span.start..];
-                if recognize_template_list(source) {
-                    *next_tok = Token::TemplateArgsStart;
-                    let cur_depth = self.token_stream.extras.depth;
-                    self.token_stream.extras.template_depths.push(cur_depth);
-                    self.opened_templates += 1;
-                }
+        if let Some((Ok(next_tok), next_span)) = &mut next
+            && (matches!(cur_tok, Token::Ident(_)) || cur_tok.is_keyword())
+            && *next_tok == Token::SymLessThan
+        {
+            let source = &self.source[next_span.start..];
+            if recognize_template_list(source) {
+                *next_tok = Token::TemplateArgsStart;
+                let cur_depth = self.token_stream.extras.depth;
+                self.token_stream.extras.template_depths.push(cur_depth);
+                self.opened_templates += 1;
             }
         }
 

--- a/crates/wgsl-parse/src/tokrepr.rs
+++ b/crates/wgsl-parse/src/tokrepr.rs
@@ -48,14 +48,12 @@ impl NamedNode for Expression {
 impl NamedNode for Statement {
     fn name(&self) -> Option<String> {
         // COMBAK: this nesting is hell. Hopefully if-let chains will stabilize soon.
-        if let Statement::Compound(stmt) = self {
-            if stmt.statements.is_empty() {
-                if let [attr] = stmt.attributes.as_slice() {
-                    if let Attribute::Custom(attr) = attr.node() {
-                        return Some(attr.name.to_string());
-                    }
-                }
-            }
+        if let Statement::Compound(stmt) = self
+            && stmt.statements.is_empty()
+            && let [attr] = stmt.attributes.as_slice()
+            && let Attribute::Custom(attr) = attr.node()
+        {
+            return Some(attr.name.to_string());
         }
         None
     }
@@ -66,14 +64,14 @@ impl<T: NamedNode + TokRepr> TokRepr for Spanned<T> {
         let node = self.node().tok_repr();
         let span = self.span().tok_repr();
 
-        if let Some(name) = self.name() {
-            if let Some(suffix) = name.strip_prefix("#") {
-                let ident = format_ident!("{}", suffix);
+        if let Some(name) = self.name()
+            && let Some(suffix) = name.strip_prefix("#")
+        {
+            let ident = format_ident!("{}", suffix);
 
-                return quote! {
-                    Spanned::new(#ident.to_owned().into(), #span)
-                };
-            }
+            return quote! {
+                Spanned::new(#ident.to_owned().into(), #span)
+            };
         }
 
         quote! {

--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,9 @@ all-features = true
 
 [advisories]
 version = 2
+ignore = [
+  { id = "RUSTSEC-2026-0173", reason = "low-priority, open issue in wesl-rs#209" },
+]
 
 [licenses]
 version = 2


### PR DESCRIPTION
There was a CI failure in #206. Since 1.94, Rust supports TOML 1.1 which allows newlines in inline tables.
The new Rust edition also supports if-let chains, hooray!! 