### PR TITLE
fix importing whole modules in eager resolution mode.

### DIFF
--- a/crates/wesl/src/import.rs
+++ b/crates/wesl/src/import.rs
@@ -323,11 +323,6 @@ pub fn resolve_eager(
         resolutions: &mut Resolutions,
         resolver: &impl Resolver,
     ) -> Result<(), Error> {
-        // resolve all module imports
-        for item in module.imports.values() {
-            load_module(&item.path, resolutions, resolver, &resolve_module)?;
-        }
-
         for decl in &module.source.global_declarations {
             if let Some(ident) = decl.ident() {
                 resolve_decl(module, &ident, resolutions, resolver, &resolve_module)?;

--- a/crates/wesl/src/lib.rs
+++ b/crates/wesl/src/lib.rs
@@ -855,6 +855,8 @@ fn compile_pre_assembly(
 
     let resolutions = if opts.imports {
         if opts.strip && opts.lazy {
+            // we can only use the lazy algorithm if stripping is enabled,
+            // because lazy will already strip unused modules.
             import::resolve_lazy(&keep, wesl, root, &resolver)?
         } else {
             import::resolve_eager(wesl, root, &resolver)?


### PR DESCRIPTION
The code expected that all imports refer to a declaration in a file.Since we now have the inline import syntax, we can now import whole modules, not just items inside.

The import statement is lazy per the spec: it does not check that the file exists, until the import is used. So one can write `import something::totally::random` and that's file. Unless you start using `random`, then it will fetch `something/totally.wesl`.


