### PR TITLE
merge all parser entrypoints to avoid codegen duplication. See lalrpop#65

### DIFF
--- a/crates/wesl-quote/src/quote_macro.rs
+++ b/crates/wesl-quote/src/quote_macro.rs
@@ -407,69 +407,69 @@ pub(crate) enum QuoteNodeKind {
 }
 
 fn quote_impl_inline(kind: QuoteNodeKind, input: TokenStream) -> TokenStream {
-    use wgsl_parse::parser::*;
+    use wgsl_parse::parser::{ParseEntryPoint, parse_tokens};
     let token_stream = FlattenRec::from(input.clone().into_iter()).peekable();
     let lexer = Lexer::new(token_stream, None);
 
     macro_rules! parser_impl {
-        ($parser:ident) => {{
-            let parser = $parser::new();
-
-            let syntax = parser.parse(lexer).unwrap_or_else(|e| {
-                let err = wgsl_parse::Error::from(e);
-                let span = err.span;
-                let mut token_stream = FlattenRec::from(input.into_iter());
-                let start = token_stream
-                    .nth(span.start)
-                    .map(|tok| tok.span())
-                    .unwrap_or(proc_macro2::Span::call_site());
-                // let end = token_stream
-                //     .nth(span.end - span.start - 1)
-                //     .map(|tok| tok.span())
-                //     .unwrap_or(proc_macro2::Span::call_site());
-                abort!(start, "{}", err)
-            });
-
-            syntax.tok_repr()
+        ($token:ident, $entrypoint:ident) => {{
+            match parse_tokens(lexer, Token::$token) {
+                Ok(ParseEntryPoint::$entrypoint(res)) => res.tok_repr(),
+                Ok(_) => unreachable!("parser parsed the wrong entrypoint"),
+                Err(e) => {
+                    let err = wgsl_parse::Error::from(e);
+                    let span = err.span;
+                    let mut token_stream = FlattenRec::from(input.into_iter());
+                    let start = token_stream
+                        .nth(span.start)
+                        .map(|tok| tok.span())
+                        .unwrap_or(proc_macro2::Span::call_site());
+                    // let end = token_stream
+                    //     .nth(span.end - span.start - 1)
+                    //     .map(|tok| tok.span())
+                    //     .unwrap_or(proc_macro2::Span::call_site());
+                    abort!(start, "{}", err)
+                }
+            }
         }};
     }
 
     match kind {
-        QuoteNodeKind::TranslationUnit => parser_impl!(TranslationUnitParser),
-        QuoteNodeKind::ImportStatement => parser_impl!(ImportStatementParser),
-        QuoteNodeKind::GlobalDeclaration => parser_impl!(GlobalDeclParser),
-        QuoteNodeKind::Literal => parser_impl!(LiteralParser),
-        QuoteNodeKind::GlobalDirective => parser_impl!(GlobalDirectiveParser),
-        QuoteNodeKind::Expression => parser_impl!(ExpressionParser),
-        QuoteNodeKind::Statement => parser_impl!(StatementParser),
+        QuoteNodeKind::TranslationUnit => parser_impl!(EntryPointTranslationUnit, TranslationUnit),
+        QuoteNodeKind::ImportStatement => parser_impl!(EntryPointImportStatement, ImportStatement),
+        QuoteNodeKind::GlobalDeclaration => parser_impl!(EntryPointGlobalDecl, GlobalDecl),
+        QuoteNodeKind::Literal => parser_impl!(EntryPointLiteral, Literal),
+        QuoteNodeKind::GlobalDirective => parser_impl!(EntryPointGlobalDirective, GlobalDirective),
+        QuoteNodeKind::Expression => parser_impl!(EntryPointExpression, Expression),
+        QuoteNodeKind::Statement => parser_impl!(EntryPointStatement, Statement),
     }
 }
 
 fn quote_impl_str(kind: QuoteNodeKind, str: &str) -> TokenStream {
-    use wgsl_parse::parser::*;
+    use wgsl_parse::parser::{ParseEntryPoint, parse_tokens};
     let lexer = wgsl_parse::lexer::Lexer::new(str);
 
     macro_rules! parser_impl {
-        ($parser:ident) => {{
-            let parser = $parser::new();
-
-            let syntax = parser.parse(lexer).unwrap_or_else(|e| {
-                let err = wgsl_parse::Error::from(e);
-                abort_call_site!("{}", err)
-            });
-
-            syntax.tok_repr()
+        ($token:ident, $entrypoint:ident) => {{
+            match parse_tokens(lexer, Token::$token) {
+                Ok(ParseEntryPoint::$entrypoint(res)) => res.tok_repr(),
+                Ok(_) => unreachable!("parser parsed the wrong entrypoint"),
+                Err(e) => {
+                    let err = wgsl_parse::Error::from(e);
+                    abort_call_site!("{}", err)
+                }
+            }
         }};
     }
 
     match kind {
-        QuoteNodeKind::TranslationUnit => parser_impl!(TranslationUnitParser),
-        QuoteNodeKind::ImportStatement => parser_impl!(ImportStatementParser),
-        QuoteNodeKind::GlobalDeclaration => parser_impl!(GlobalDeclParser),
-        QuoteNodeKind::Literal => parser_impl!(LiteralParser),
-        QuoteNodeKind::GlobalDirective => parser_impl!(GlobalDirectiveParser),
-        QuoteNodeKind::Expression => parser_impl!(ExpressionParser),
-        QuoteNodeKind::Statement => parser_impl!(StatementParser),
+        QuoteNodeKind::TranslationUnit => parser_impl!(EntryPointTranslationUnit, TranslationUnit),
+        QuoteNodeKind::ImportStatement => parser_impl!(EntryPointImportStatement, ImportStatement),
+        QuoteNodeKind::GlobalDeclaration => parser_impl!(EntryPointGlobalDecl, GlobalDecl),
+        QuoteNodeKind::Literal => parser_impl!(EntryPointLiteral, Literal),
+        QuoteNodeKind::GlobalDirective => parser_impl!(EntryPointGlobalDirective, GlobalDirective),
+        QuoteNodeKind::Expression => parser_impl!(EntryPointExpression, Expression),
+        QuoteNodeKind::Statement => parser_impl!(EntryPointStatement, Statement),
     }
 }
 

--- a/crates/wgsl-parse/src/lexer.rs
+++ b/crates/wgsl-parse/src/lexer.rs
@@ -261,6 +261,21 @@ pub struct LexerState {
     extras = LexerState,
     error = ParseError)]
 pub enum Token {
+    // HACK: parsing entrypoints.
+    // See: https://github.com/lalrpop/lalrpop/issues/65#issuecomment-516769995
+    // The first token provided by the lexer to the parser must be one of these tokens.
+    // They tell the parser which syntax node to parse. The parser returns a union type
+    // containing the corresponding syntax node type.
+    EntryPointTryTemplateList,
+    EntryPointTranslationUnit,
+    EntryPointGlobalDecl,
+    EntryPointLiteral,
+    EntryPointGlobalDirective,
+    EntryPointExpression,
+    EntryPointStatement,
+    #[cfg(feature = "imports")]
+    EntryPointImportStatement,
+
     #[token("//", parse_line_comment)]
     LineComment,
     #[token("/*", parse_block_comment, priority = 2)]
@@ -616,6 +631,15 @@ impl Display for Token {
     /// This display implementation is used for error messages.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Token::EntryPointTryTemplateList => f.write_str("EntryPointTryTemplateList"),
+            Token::EntryPointTranslationUnit => f.write_str("EntryPointTranslationUnit"),
+            Token::EntryPointGlobalDecl => f.write_str("EntryPointGlobalDecl"),
+            Token::EntryPointLiteral => f.write_str("EntryPointLiteral"),
+            Token::EntryPointGlobalDirective => f.write_str("EntryPointGlobalDirective"),
+            Token::EntryPointExpression => f.write_str("EntryPointExpression"),
+            Token::EntryPointStatement => f.write_str("EntryPointStatement"),
+            #[cfg(feature = "imports")]
+            Token::EntryPointImportStatement => f.write_str("EntryPointImportStatement"),
             Token::LineComment => f.write_str("// line comment"),
             Token::BlockComment => f.write_str("/* block comment */"),
             Token::Ignored => unreachable!(),

--- a/crates/wgsl-parse/src/parser.rs
+++ b/crates/wgsl-parse/src/parser.rs
@@ -2,8 +2,8 @@ use std::str::FromStr;
 
 use crate::{
     error::Error,
-    lexer::{Lexer, TokenIterator},
-    syntax::{Expression, GlobalDeclaration, GlobalDirective, Statement, TranslationUnit},
+    lexer::{Lexer, Token, TokenIterator},
+    syntax::*,
 };
 
 use lalrpop_util::lalrpop_mod;
@@ -17,21 +17,39 @@ lalrpop_mod!(
     wgsl_recognize
 );
 
-#[cfg(feature = "imports")]
-pub use wgsl::ImportStatementParser;
+pub use crate::parser_support::ParseEntryPoint;
+use wgsl::EntryPointParser;
 
-pub use wgsl::{
-    ExpressionParser, GlobalDeclParser, GlobalDirectiveParser, LiteralParser, StatementParser,
-    TranslationUnitParser, TryTemplateListParser,
-};
+macro_rules! parse {
+    ($source:expr, $token:ident, $entrypoint:ident) => {{
+        match parse_tokens(Lexer::new($source), Token::$token) {
+            Ok(ParseEntryPoint::$entrypoint(res)) => Ok(res),
+            Ok(_) => unreachable!("parser parsed the wrong entrypoint"),
+            Err(e) => Err(e),
+        }
+    }};
+}
+
+/// Parse a token stream into a syntax tree.
+///
+/// Low-level implementation, you probably don't want to use this. See [`parse_str`].
+///
+/// The `entrypoint` parameter must be one of the `EntryPointXXX` tokens, which tells the
+/// parser which syntax node to expect. It returns the [`ParseEntryPoint`] union type.
+pub fn parse_tokens(
+    lexer: impl TokenIterator,
+    entrypoint: Token,
+) -> Result<ParseEntryPoint, Error> {
+    let lexer = std::iter::once(Ok((0, entrypoint, 0))).chain(lexer);
+    let parser = EntryPointParser::new();
+    parser.parse(lexer).map_err(Into::into)
+}
 
 /// Parse a string into a syntax tree ([`TranslationUnit`]).
 ///
 /// Identical to [`TranslationUnit::from_str`].
 pub fn parse_str(source: &str) -> Result<TranslationUnit, Error> {
-    let lexer = Lexer::new(source);
-    let parser = TranslationUnitParser::new();
-    parser.parse(lexer).map_err(Into::into)
+    parse!(source, EntryPointTranslationUnit, TranslationUnit)
 }
 
 /// Test whether a string represent a valid WGSL module ([`TranslationUnit`]).
@@ -44,53 +62,53 @@ pub fn recognize_str(source: &str) -> Result<(), Error> {
 }
 
 pub fn recognize_template_list(lexer: impl TokenIterator) -> Result<(), Error> {
-    let parser = TryTemplateListParser::new();
-    parser.parse(lexer).map(|_| ()).map_err(Into::into)
+    match parse_tokens(lexer, Token::EntryPointTryTemplateList) {
+        Ok(ParseEntryPoint::TryTemplateList(_)) => Ok(()),
+        Ok(_) => unreachable!("parser parsed the wrong entrypoint"),
+        Err(e) => Err(e),
+    }
 }
 
 impl FromStr for TranslationUnit {
     type Err = Error;
 
     fn from_str(source: &str) -> Result<Self, Self::Err> {
-        let lexer = Lexer::new(source);
-        let parser = TranslationUnitParser::new();
-        parser.parse(lexer).map_err(Into::into)
+        parse!(source, EntryPointTranslationUnit, TranslationUnit)
     }
 }
 impl FromStr for GlobalDirective {
     type Err = Error;
 
     fn from_str(source: &str) -> Result<Self, Self::Err> {
-        let lexer = Lexer::new(source);
-        let parser = GlobalDirectiveParser::new();
-        parser.parse(lexer).map_err(Into::into)
+        parse!(source, EntryPointGlobalDirective, GlobalDirective)
     }
 }
 impl FromStr for GlobalDeclaration {
     type Err = Error;
 
     fn from_str(source: &str) -> Result<Self, Self::Err> {
-        let lexer = Lexer::new(source);
-        let parser = GlobalDeclParser::new();
-        parser.parse(lexer).map_err(Into::into)
+        parse!(source, EntryPointGlobalDecl, GlobalDecl)
     }
 }
 impl FromStr for Statement {
     type Err = Error;
 
     fn from_str(source: &str) -> Result<Self, Self::Err> {
-        let lexer = Lexer::new(source);
-        let parser = StatementParser::new();
-        parser.parse(lexer).map_err(Into::into)
+        parse!(source, EntryPointStatement, Statement)
     }
 }
 impl FromStr for Expression {
     type Err = Error;
 
     fn from_str(source: &str) -> Result<Self, Self::Err> {
-        let lexer = Lexer::new(source);
-        let parser = ExpressionParser::new();
-        parser.parse(lexer).map_err(Into::into)
+        parse!(source, EntryPointExpression, Expression)
+    }
+}
+impl FromStr for LiteralExpression {
+    type Err = Error;
+
+    fn from_str(source: &str) -> Result<Self, Self::Err> {
+        parse!(source, EntryPointLiteral, Literal)
     }
 }
 #[cfg(feature = "imports")]
@@ -98,8 +116,6 @@ impl FromStr for crate::syntax::ImportStatement {
     type Err = Error;
 
     fn from_str(source: &str) -> Result<Self, Self::Err> {
-        let lexer = Lexer::new(source);
-        let parser = ImportStatementParser::new();
-        parser.parse(lexer).map_err(Into::into)
+        parse!(source, EntryPointImportStatement, ImportStatement)
     }
 }

--- a/crates/wgsl-parse/src/parser_support.rs
+++ b/crates/wgsl-parse/src/parser_support.rs
@@ -12,6 +12,20 @@ use crate::{
 
 type E = ParseError;
 
+// HACK: parsing entrypoints.
+// see: https://github.com/lalrpop/lalrpop/issues/65#issuecomment-516769995
+pub enum ParseEntryPoint {
+    TryTemplateList(Span),
+    TranslationUnit(TranslationUnit),
+    GlobalDecl(GlobalDeclaration),
+    Literal(LiteralExpression),
+    GlobalDirective(GlobalDirective),
+    Expression(Expression),
+    Statement(Statement),
+    #[cfg(feature = "imports")]
+    ImportStatement(ImportStatement),
+}
+
 pub(crate) enum Component {
     Named(Ident),
     Index(ExpressionNode),

--- a/crates/wgsl-parse/src/wgsl.lalrpop
+++ b/crates/wgsl-parse/src/wgsl.lalrpop
@@ -13,6 +13,18 @@ extern {
     type Location = usize;
     type Error = (usize, ParseError, usize);
     enum Token {
+        // HACK: parsing entrypoints.
+        // see: https://github.com/lalrpop/lalrpop/issues/65#issuecomment-516769995
+        EntryPointTryTemplateList => Token::EntryPointTryTemplateList,
+        EntryPointTranslationUnit => Token::EntryPointTranslationUnit,
+        EntryPointGlobalDecl => Token::EntryPointGlobalDecl,
+        EntryPointLiteral => Token::EntryPointLiteral,
+        EntryPointGlobalDirective => Token::EntryPointGlobalDirective,
+        EntryPointExpression => Token::EntryPointExpression,
+        EntryPointStatement => Token::EntryPointStatement,
+        #[cfg(feature = "imports")]
+        EntryPointImportStatement => Token::EntryPointImportStatement,
+
         // syntactic tokens
         // https://www.w3.org/TR/WGSL/#syntactic-tokens
         "&" => Token::SymAnd,
@@ -166,12 +178,26 @@ Keyword: String = {
     "import" => <>.to_string(),
 };
 
+// HACK: parsing entrypoints.
+// see: https://github.com/lalrpop/lalrpop/issues/65#issuecomment-516769995
+pub EntryPoint: ParseEntryPoint = {
+    EntryPointTryTemplateList <TryTemplateList> => ParseEntryPoint::TryTemplateList(<>),
+    EntryPointTranslationUnit <TranslationUnit> => ParseEntryPoint::TranslationUnit(<>),
+    EntryPointGlobalDecl <GlobalDecl> => ParseEntryPoint::GlobalDecl(<>),
+    EntryPointLiteral <Literal> => ParseEntryPoint::Literal(<>),
+    EntryPointGlobalDirective <GlobalDirective> => ParseEntryPoint::GlobalDirective(<>),
+    EntryPointExpression <Expression> => ParseEntryPoint::Expression(<>),
+    EntryPointStatement <Statement> => ParseEntryPoint::Statement(<>),
+    #[cfg(feature = "imports")]
+    EntryPointImportStatement <ImportStatement> => ParseEntryPoint::ImportStatement(<>)
+};
+
 // the grammar rules are laid out in the same order as in the spec.
 // following the spec at this date: https://www.w3.org/TR/2024/WD-WGSL-20240731/
 
 // custom entrypoint called by the lexer when it sees [Token::Ident, Token::SymLessThan].
 // if this parse succeeds, the next token emitted by the lexer will be TokTemplateList.
- pub TryTemplateList: Span = {
+TryTemplateList: Span = {
     <l:@L> TokTemplateArgsStart TemplateArgCommaList TokTemplateArgsEnd <r:@R> => Span::new(l..r),
 };
 
@@ -182,7 +208,7 @@ Keyword: String = {
 // 2. WGSL MODULE
 // https://www.w3.org/TR/WGSL/#wgsl-module
 
-pub TranslationUnit: TranslationUnit = {
+TranslationUnit: TranslationUnit = {
     #[cfg(not(feature = "imports"))]
     <global_directives: GlobalDirective*> <global_declarations: GlobalDeclarationNode*> => TranslationUnit {
         global_directives, global_declarations
@@ -193,7 +219,7 @@ pub TranslationUnit: TranslationUnit = {
     },
 };
 
-pub GlobalDecl: GlobalDeclaration = {
+GlobalDecl: GlobalDeclaration = {
     ";"                        => GlobalDeclaration::Void,
     <GlobalVariableDecl> ";"   => GlobalDeclaration::Declaration(<>),
     <GlobalValueDecl> ";"      => GlobalDeclaration::Declaration(<>),
@@ -215,7 +241,7 @@ DiagnosticRuleName: String = {
 
 // XXX: non-conformant
 // https://www.w3.org/TR/WGSL/#syntax-literal
-pub Literal: LiteralExpression = {
+Literal: LiteralExpression = {
     TokAbstractInt   => LiteralExpression::AbstractInt(<>),
     TokAbstractFloat => LiteralExpression::AbstractFloat(<>),
     TokI32           => LiteralExpression::I32(<>),
@@ -314,7 +340,7 @@ TemplateArgExpression: TemplateArg = {
 // 4. DIRECTIVES
 // https://www.w3.org/TR/WGSL/#directives
 
-pub GlobalDirective: GlobalDirective = {
+GlobalDirective: GlobalDirective = {
     DiagnosticDirective => GlobalDirective::Diagnostic(<>),
     EnableDirective     => GlobalDirective::Enable(<>),
     RequiresDirective   => GlobalDirective::Requires(<>),
@@ -790,7 +816,7 @@ BitwiseExpression: Expression = {
     }),
 };
 
-pub Expression: Expression = {
+Expression: Expression = {
     RelationalExpression,
     <left: Spanned<ShortCircuitOrExpression>> "||" <right: Spanned<RelationalExpression>> => Expression::Binary(BinaryExpression {
         operator: BinaryOperator::ShortCircuitOr, left, right
@@ -1124,7 +1150,7 @@ ConstAssertStatement: ConstAssertStatement = {
     },
 };
 
-pub Statement: Statement = {
+Statement: Statement = {
     ";" => Statement::Void,
     <ReturnStatement> ";" => Statement::Return(<>),
     <IfStatement> => Statement::If(<>),
@@ -1243,7 +1269,7 @@ PathIdent: String = {
 };
 
 #[cfg(feature = "imports")]
-pub ImportStatement: ImportStatement = {
+ImportStatement: ImportStatement = {
     #[cfg(not(feature = "attributes"))]
     "import" <path: ModulePath?> <content: ImportContent> ";" => {
         ImportStatement { path, content }


### PR DESCRIPTION
`wgsl-parse` took 25s to compile. The parser was running 7 times and generating 7x as much code. This is caused by a bug in the parser generator (https://github.com/lalrpop/lalrpop/issues/65) which regenerates a full parser for each entry point (expressions, statements...) even if they share production rules.

In a subsequent PR, I'll reduce compile times further by including the generated parser code in the source instead of invoking lalrpop in build.rs. This should reduce compile times a lot more.
