### PR TITLE
Add unknown type

### DIFF
--- a/crates/wesl-quote/src/quote_macro.rs
+++ b/crates/wesl-quote/src/quote_macro.rs
@@ -407,69 +407,69 @@ pub(crate) enum QuoteNodeKind {
 }
 
 fn quote_impl_inline(kind: QuoteNodeKind, input: TokenStream) -> TokenStream {
-    use wgsl_parse::parser::*;
+    use wgsl_parse::parser::{ParseEntryPoint, parse_tokens};
     let token_stream = FlattenRec::from(input.clone().into_iter()).peekable();
     let lexer = Lexer::new(token_stream, None);
 
     macro_rules! parser_impl {
-        ($parser:ident) => {{
-            let parser = $parser::new();
-
-            let syntax = parser.parse(lexer).unwrap_or_else(|e| {
-                let err = wgsl_parse::Error::from(e);
-                let span = err.span;
-                let mut token_stream = FlattenRec::from(input.into_iter());
-                let start = token_stream
-                    .nth(span.start)
-                    .map(|tok| tok.span())
-                    .unwrap_or(proc_macro2::Span::call_site());
-                // let end = token_stream
-                //     .nth(span.end - span.start - 1)
-                //     .map(|tok| tok.span())
-                //     .unwrap_or(proc_macro2::Span::call_site());
-                abort!(start, "{}", err)
-            });
-
-            syntax.tok_repr()
+        ($token:ident, $entrypoint:ident) => {{
+            match parse_tokens(lexer, Token::$token) {
+                Ok(ParseEntryPoint::$entrypoint(res)) => res.tok_repr(),
+                Ok(_) => unreachable!("parser parsed the wrong entrypoint"),
+                Err(e) => {
+                    let err = wgsl_parse::Error::from(e);
+                    let span = err.span;
+                    let mut token_stream = FlattenRec::from(input.into_iter());
+                    let start = token_stream
+                        .nth(span.start)
+                        .map(|tok| tok.span())
+                        .unwrap_or(proc_macro2::Span::call_site());
+                    // let end = token_stream
+                    //     .nth(span.end - span.start - 1)
+                    //     .map(|tok| tok.span())
+                    //     .unwrap_or(proc_macro2::Span::call_site());
+                    abort!(start, "{}", err)
+                }
+            }
         }};
     }
 
     match kind {
-        QuoteNodeKind::TranslationUnit => parser_impl!(TranslationUnitParser),
-        QuoteNodeKind::ImportStatement => parser_impl!(ImportStatementParser),
-        QuoteNodeKind::GlobalDeclaration => parser_impl!(GlobalDeclParser),
-        QuoteNodeKind::Literal => parser_impl!(LiteralParser),
-        QuoteNodeKind::GlobalDirective => parser_impl!(GlobalDirectiveParser),
-        QuoteNodeKind::Expression => parser_impl!(ExpressionParser),
-        QuoteNodeKind::Statement => parser_impl!(StatementParser),
+        QuoteNodeKind::TranslationUnit => parser_impl!(EntryPointTranslationUnit, TranslationUnit),
+        QuoteNodeKind::ImportStatement => parser_impl!(EntryPointImportStatement, ImportStatement),
+        QuoteNodeKind::GlobalDeclaration => parser_impl!(EntryPointGlobalDecl, GlobalDecl),
+        QuoteNodeKind::Literal => parser_impl!(EntryPointLiteral, Literal),
+        QuoteNodeKind::GlobalDirective => parser_impl!(EntryPointGlobalDirective, GlobalDirective),
+        QuoteNodeKind::Expression => parser_impl!(EntryPointExpression, Expression),
+        QuoteNodeKind::Statement => parser_impl!(EntryPointStatement, Statement),
     }
 }
 
 fn quote_impl_str(kind: QuoteNodeKind, str: &str) -> TokenStream {
-    use wgsl_parse::parser::*;
+    use wgsl_parse::parser::{ParseEntryPoint, parse_tokens};
     let lexer = wgsl_parse::lexer::Lexer::new(str);
 
     macro_rules! parser_impl {
-        ($parser:ident) => {{
-            let parser = $parser::new();
-
-            let syntax = parser.parse(lexer).unwrap_or_else(|e| {
-                let err = wgsl_parse::Error::from(e);
-                abort_call_site!("{}", err)
-            });
-
-            syntax.tok_repr()
+        ($token:ident, $entrypoint:ident) => {{
+            match parse_tokens(lexer, Token::$token) {
+                Ok(ParseEntryPoint::$entrypoint(res)) => res.tok_repr(),
+                Ok(_) => unreachable!("parser parsed the wrong entrypoint"),
+                Err(e) => {
+                    let err = wgsl_parse::Error::from(e);
+                    abort_call_site!("{}", err)
+                }
+            }
         }};
     }
 
     match kind {
-        QuoteNodeKind::TranslationUnit => parser_impl!(TranslationUnitParser),
-        QuoteNodeKind::ImportStatement => parser_impl!(ImportStatementParser),
-        QuoteNodeKind::GlobalDeclaration => parser_impl!(GlobalDeclParser),
-        QuoteNodeKind::Literal => parser_impl!(LiteralParser),
-        QuoteNodeKind::GlobalDirective => parser_impl!(GlobalDirectiveParser),
-        QuoteNodeKind::Expression => parser_impl!(ExpressionParser),
-        QuoteNodeKind::Statement => parser_impl!(StatementParser),
+        QuoteNodeKind::TranslationUnit => parser_impl!(EntryPointTranslationUnit, TranslationUnit),
+        QuoteNodeKind::ImportStatement => parser_impl!(EntryPointImportStatement, ImportStatement),
+        QuoteNodeKind::GlobalDeclaration => parser_impl!(EntryPointGlobalDecl, GlobalDecl),
+        QuoteNodeKind::Literal => parser_impl!(EntryPointLiteral, Literal),
+        QuoteNodeKind::GlobalDirective => parser_impl!(EntryPointGlobalDirective, GlobalDirective),
+        QuoteNodeKind::Expression => parser_impl!(EntryPointExpression, Expression),
+        QuoteNodeKind::Statement => parser_impl!(EntryPointStatement, Statement),
     }
 }
 

--- a/crates/wesl/src/eval/to_expr.rs
+++ b/crates/wesl/src/eval/to_expr.rs
@@ -284,6 +284,7 @@ impl ToExpr for Type {
                 Ok(ty)
             }
             Type::Sampler(_) => Ok(TypeExpression::new(ident.unwrap())),
+            Type::Unknown => Err(E::NotConstructible(Type::Unknown)),
             #[cfg(feature = "naga-ext")]
             Type::RayQuery(flags) | Type::AccelerationStructure(flags) => Ok(TypeExpression {
                 path: None,

--- a/crates/wesl/src/idents.rs
+++ b/crates/wesl/src/idents.rs
@@ -63,7 +63,7 @@ impl BuiltinIdent for Type {
             Type::Ref(_, _, _) => builtin_ident("__ref"),
             Type::Texture(texture_type) => texture_type.builtin_ident(),
             Type::Sampler(sampler_type) => sampler_type.builtin_ident(),
-            Type::Unknown => None,
+            Type::Unknown => builtin_ident("__unknown"),
             #[cfg(feature = "naga-ext")]
             Type::I64 => builtin_ident("i64"),
             #[cfg(feature = "naga-ext")]

--- a/crates/wesl/src/idents.rs
+++ b/crates/wesl/src/idents.rs
@@ -63,6 +63,7 @@ impl BuiltinIdent for Type {
             Type::Ref(_, _, _) => builtin_ident("__ref"),
             Type::Texture(texture_type) => texture_type.builtin_ident(),
             Type::Sampler(sampler_type) => sampler_type.builtin_ident(),
+            Type::Unknown => None,
             #[cfg(feature = "naga-ext")]
             Type::I64 => builtin_ident("i64"),
             #[cfg(feature = "naga-ext")]

--- a/crates/wgsl-parse/src/lexer.rs
+++ b/crates/wgsl-parse/src/lexer.rs
@@ -261,6 +261,21 @@ pub struct LexerState {
     extras = LexerState,
     error = ParseError)]
 pub enum Token {
+    // HACK: parsing entrypoints.
+    // See: https://github.com/lalrpop/lalrpop/issues/65#issuecomment-516769995
+    // The first token provided by the lexer to the parser must be one of these tokens.
+    // They tell the parser which syntax node to parse. The parser returns a union type
+    // containing the corresponding syntax node type.
+    EntryPointTryTemplateList,
+    EntryPointTranslationUnit,
+    EntryPointGlobalDecl,
+    EntryPointLiteral,
+    EntryPointGlobalDirective,
+    EntryPointExpression,
+    EntryPointStatement,
+    #[cfg(feature = "imports")]
+    EntryPointImportStatement,
+
     #[token("//", parse_line_comment)]
     LineComment,
     #[token("/*", parse_block_comment, priority = 2)]
@@ -616,6 +631,15 @@ impl Display for Token {
     /// This display implementation is used for error messages.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Token::EntryPointTryTemplateList => f.write_str("EntryPointTryTemplateList"),
+            Token::EntryPointTranslationUnit => f.write_str("EntryPointTranslationUnit"),
+            Token::EntryPointGlobalDecl => f.write_str("EntryPointGlobalDecl"),
+            Token::EntryPointLiteral => f.write_str("EntryPointLiteral"),
+            Token::EntryPointGlobalDirective => f.write_str("EntryPointGlobalDirective"),
+            Token::EntryPointExpression => f.write_str("EntryPointExpression"),
+            Token::EntryPointStatement => f.write_str("EntryPointStatement"),
+            #[cfg(feature = "imports")]
+            Token::EntryPointImportStatement => f.write_str("EntryPointImportStatement"),
             Token::LineComment => f.write_str("// line comment"),
             Token::BlockComment => f.write_str("/* block comment */"),
             Token::Ignored => unreachable!(),

--- a/crates/wgsl-parse/src/parser.rs
+++ b/crates/wgsl-parse/src/parser.rs
@@ -2,8 +2,8 @@ use std::str::FromStr;
 
 use crate::{
     error::Error,
-    lexer::{Lexer, TokenIterator},
-    syntax::{Expression, GlobalDeclaration, GlobalDirective, Statement, TranslationUnit},
+    lexer::{Lexer, Token, TokenIterator},
+    syntax::*,
 };
 
 use lalrpop_util::lalrpop_mod;
@@ -17,21 +17,39 @@ lalrpop_mod!(
     wgsl_recognize
 );
 
-#[cfg(feature = "imports")]
-pub use wgsl::ImportStatementParser;
+pub use crate::parser_support::ParseEntryPoint;
+use wgsl::EntryPointParser;
 
-pub use wgsl::{
-    ExpressionParser, GlobalDeclParser, GlobalDirectiveParser, LiteralParser, StatementParser,
-    TranslationUnitParser, TryTemplateListParser,
-};
+macro_rules! parse {
+    ($source:expr, $token:ident, $entrypoint:ident) => {{
+        match parse_tokens(Lexer::new($source), Token::$token) {
+            Ok(ParseEntryPoint::$entrypoint(res)) => Ok(res),
+            Ok(_) => unreachable!("parser parsed the wrong entrypoint"),
+            Err(e) => Err(e),
+        }
+    }};
+}
+
+/// Parse a token stream into a syntax tree.
+///
+/// Low-level implementation, you probably don't want to use this. See [`parse_str`].
+///
+/// The `entrypoint` parameter must be one of the `EntryPointXXX` tokens, which tells the
+/// parser which syntax node to expect. It returns the [`ParseEntryPoint`] union type.
+pub fn parse_tokens(
+    lexer: impl TokenIterator,
+    entrypoint: Token,
+) -> Result<ParseEntryPoint, Error> {
+    let lexer = std::iter::once(Ok((0, entrypoint, 0))).chain(lexer);
+    let parser = EntryPointParser::new();
+    parser.parse(lexer).map_err(Into::into)
+}
 
 /// Parse a string into a syntax tree ([`TranslationUnit`]).
 ///
 /// Identical to [`TranslationUnit::from_str`].
 pub fn parse_str(source: &str) -> Result<TranslationUnit, Error> {
-    let lexer = Lexer::new(source);
-    let parser = TranslationUnitParser::new();
-    parser.parse(lexer).map_err(Into::into)
+    parse!(source, EntryPointTranslationUnit, TranslationUnit)
 }
 
 /// Test whether a string represent a valid WGSL module ([`TranslationUnit`]).
@@ -44,53 +62,53 @@ pub fn recognize_str(source: &str) -> Result<(), Error> {
 }
 
 pub fn recognize_template_list(lexer: impl TokenIterator) -> Result<(), Error> {
-    let parser = TryTemplateListParser::new();
-    parser.parse(lexer).map(|_| ()).map_err(Into::into)
+    match parse_tokens(lexer, Token::EntryPointTryTemplateList) {
+        Ok(ParseEntryPoint::TryTemplateList(_)) => Ok(()),
+        Ok(_) => unreachable!("parser parsed the wrong entrypoint"),
+        Err(e) => Err(e),
+    }
 }
 
 impl FromStr for TranslationUnit {
     type Err = Error;
 
     fn from_str(source: &str) -> Result<Self, Self::Err> {
-        let lexer = Lexer::new(source);
-        let parser = TranslationUnitParser::new();
-        parser.parse(lexer).map_err(Into::into)
+        parse!(source, EntryPointTranslationUnit, TranslationUnit)
     }
 }
 impl FromStr for GlobalDirective {
     type Err = Error;
 
     fn from_str(source: &str) -> Result<Self, Self::Err> {
-        let lexer = Lexer::new(source);
-        let parser = GlobalDirectiveParser::new();
-        parser.parse(lexer).map_err(Into::into)
+        parse!(source, EntryPointGlobalDirective, GlobalDirective)
     }
 }
 impl FromStr for GlobalDeclaration {
     type Err = Error;
 
     fn from_str(source: &str) -> Result<Self, Self::Err> {
-        let lexer = Lexer::new(source);
-        let parser = GlobalDeclParser::new();
-        parser.parse(lexer).map_err(Into::into)
+        parse!(source, EntryPointGlobalDecl, GlobalDecl)
     }
 }
 impl FromStr for Statement {
     type Err = Error;
 
     fn from_str(source: &str) -> Result<Self, Self::Err> {
-        let lexer = Lexer::new(source);
-        let parser = StatementParser::new();
-        parser.parse(lexer).map_err(Into::into)
+        parse!(source, EntryPointStatement, Statement)
     }
 }
 impl FromStr for Expression {
     type Err = Error;
 
     fn from_str(source: &str) -> Result<Self, Self::Err> {
-        let lexer = Lexer::new(source);
-        let parser = ExpressionParser::new();
-        parser.parse(lexer).map_err(Into::into)
+        parse!(source, EntryPointExpression, Expression)
+    }
+}
+impl FromStr for LiteralExpression {
+    type Err = Error;
+
+    fn from_str(source: &str) -> Result<Self, Self::Err> {
+        parse!(source, EntryPointLiteral, Literal)
     }
 }
 #[cfg(feature = "imports")]
@@ -98,8 +116,6 @@ impl FromStr for crate::syntax::ImportStatement {
     type Err = Error;
 
     fn from_str(source: &str) -> Result<Self, Self::Err> {
-        let lexer = Lexer::new(source);
-        let parser = ImportStatementParser::new();
-        parser.parse(lexer).map_err(Into::into)
+        parse!(source, EntryPointImportStatement, ImportStatement)
     }
 }

--- a/crates/wgsl-parse/src/parser_support.rs
+++ b/crates/wgsl-parse/src/parser_support.rs
@@ -12,6 +12,20 @@ use crate::{
 
 type E = ParseError;
 
+// HACK: parsing entrypoints.
+// see: https://github.com/lalrpop/lalrpop/issues/65#issuecomment-516769995
+pub enum ParseEntryPoint {
+    TryTemplateList(Span),
+    TranslationUnit(TranslationUnit),
+    GlobalDecl(GlobalDeclaration),
+    Literal(LiteralExpression),
+    GlobalDirective(GlobalDirective),
+    Expression(Expression),
+    Statement(Statement),
+    #[cfg(feature = "imports")]
+    ImportStatement(ImportStatement),
+}
+
 pub(crate) enum Component {
     Named(Ident),
     Index(ExpressionNode),

--- a/crates/wgsl-parse/src/wgsl.lalrpop
+++ b/crates/wgsl-parse/src/wgsl.lalrpop
@@ -13,6 +13,18 @@ extern {
     type Location = usize;
     type Error = (usize, ParseError, usize);
     enum Token {
+        // HACK: parsing entrypoints.
+        // see: https://github.com/lalrpop/lalrpop/issues/65#issuecomment-516769995
+        EntryPointTryTemplateList => Token::EntryPointTryTemplateList,
+        EntryPointTranslationUnit => Token::EntryPointTranslationUnit,
+        EntryPointGlobalDecl => Token::EntryPointGlobalDecl,
+        EntryPointLiteral => Token::EntryPointLiteral,
+        EntryPointGlobalDirective => Token::EntryPointGlobalDirective,
+        EntryPointExpression => Token::EntryPointExpression,
+        EntryPointStatement => Token::EntryPointStatement,
+        #[cfg(feature = "imports")]
+        EntryPointImportStatement => Token::EntryPointImportStatement,
+
         // syntactic tokens
         // https://www.w3.org/TR/WGSL/#syntactic-tokens
         "&" => Token::SymAnd,
@@ -166,12 +178,26 @@ Keyword: String = {
     "import" => <>.to_string(),
 };
 
+// HACK: parsing entrypoints.
+// see: https://github.com/lalrpop/lalrpop/issues/65#issuecomment-516769995
+pub EntryPoint: ParseEntryPoint = {
+    EntryPointTryTemplateList <TryTemplateList> => ParseEntryPoint::TryTemplateList(<>),
+    EntryPointTranslationUnit <TranslationUnit> => ParseEntryPoint::TranslationUnit(<>),
+    EntryPointGlobalDecl <GlobalDecl> => ParseEntryPoint::GlobalDecl(<>),
+    EntryPointLiteral <Literal> => ParseEntryPoint::Literal(<>),
+    EntryPointGlobalDirective <GlobalDirective> => ParseEntryPoint::GlobalDirective(<>),
+    EntryPointExpression <Expression> => ParseEntryPoint::Expression(<>),
+    EntryPointStatement <Statement> => ParseEntryPoint::Statement(<>),
+    #[cfg(feature = "imports")]
+    EntryPointImportStatement <ImportStatement> => ParseEntryPoint::ImportStatement(<>)
+};
+
 // the grammar rules are laid out in the same order as in the spec.
 // following the spec at this date: https://www.w3.org/TR/2024/WD-WGSL-20240731/
 
 // custom entrypoint called by the lexer when it sees [Token::Ident, Token::SymLessThan].
 // if this parse succeeds, the next token emitted by the lexer will be TokTemplateList.
- pub TryTemplateList: Span = {
+TryTemplateList: Span = {
     <l:@L> TokTemplateArgsStart TemplateArgCommaList TokTemplateArgsEnd <r:@R> => Span::new(l..r),
 };
 
@@ -182,7 +208,7 @@ Keyword: String = {
 // 2. WGSL MODULE
 // https://www.w3.org/TR/WGSL/#wgsl-module
 
-pub TranslationUnit: TranslationUnit = {
+TranslationUnit: TranslationUnit = {
     #[cfg(not(feature = "imports"))]
     <global_directives: GlobalDirective*> <global_declarations: GlobalDeclarationNode*> => TranslationUnit {
         global_directives, global_declarations
@@ -193,7 +219,7 @@ pub TranslationUnit: TranslationUnit = {
     },
 };
 
-pub GlobalDecl: GlobalDeclaration = {
+GlobalDecl: GlobalDeclaration = {
     ";"                        => GlobalDeclaration::Void,
     <GlobalVariableDecl> ";"   => GlobalDeclaration::Declaration(<>),
     <GlobalValueDecl> ";"      => GlobalDeclaration::Declaration(<>),
@@ -215,7 +241,7 @@ DiagnosticRuleName: String = {
 
 // XXX: non-conformant
 // https://www.w3.org/TR/WGSL/#syntax-literal
-pub Literal: LiteralExpression = {
+Literal: LiteralExpression = {
     TokAbstractInt   => LiteralExpression::AbstractInt(<>),
     TokAbstractFloat => LiteralExpression::AbstractFloat(<>),
     TokI32           => LiteralExpression::I32(<>),
@@ -314,7 +340,7 @@ TemplateArgExpression: TemplateArg = {
 // 4. DIRECTIVES
 // https://www.w3.org/TR/WGSL/#directives
 
-pub GlobalDirective: GlobalDirective = {
+GlobalDirective: GlobalDirective = {
     DiagnosticDirective => GlobalDirective::Diagnostic(<>),
     EnableDirective     => GlobalDirective::Enable(<>),
     RequiresDirective   => GlobalDirective::Requires(<>),
@@ -790,7 +816,7 @@ BitwiseExpression: Expression = {
     }),
 };
 
-pub Expression: Expression = {
+Expression: Expression = {
     RelationalExpression,
     <left: Spanned<ShortCircuitOrExpression>> "||" <right: Spanned<RelationalExpression>> => Expression::Binary(BinaryExpression {
         operator: BinaryOperator::ShortCircuitOr, left, right
@@ -1124,7 +1150,7 @@ ConstAssertStatement: ConstAssertStatement = {
     },
 };
 
-pub Statement: Statement = {
+Statement: Statement = {
     ";" => Statement::Void,
     <ReturnStatement> ";" => Statement::Return(<>),
     <IfStatement> => Statement::If(<>),
@@ -1243,7 +1269,7 @@ PathIdent: String = {
 };
 
 #[cfg(feature = "imports")]
-pub ImportStatement: ImportStatement = {
+ImportStatement: ImportStatement = {
     #[cfg(not(feature = "attributes"))]
     "import" <path: ModulePath?> <content: ImportContent> ";" => {
         ImportStatement { path, content }

--- a/crates/wgsl-types/src/builtin/ctor.rs
+++ b/crates/wgsl-types/src/builtin/ctor.rs
@@ -904,7 +904,9 @@ impl Instance {
             | Type::Ptr(_, _, _)
             | Type::Ref(_, _, _)
             | Type::Texture(_)
-            | Type::Sampler(_) => Err(E::NotConstructible(ty.clone())),
+            | Type::Sampler(_)
+            | Type::Unknown => Err(E::NotConstructible(ty.clone())),
+
             #[cfg(feature = "naga-ext")]
             Type::I64 => Ok(LiteralInstance::I64(0).into()),
             #[cfg(feature = "naga-ext")]

--- a/crates/wgsl-types/src/builtin/mod.rs
+++ b/crates/wgsl-types/src/builtin/mod.rs
@@ -268,7 +268,8 @@ pub fn call_ctor(ty: &Type, args: &[Instance], stage: ShaderStage) -> Result<Ins
             | Type::Ptr(_, _, _)
             | Type::Ref(_, _, _)
             | Type::Texture(_)
-            | Type::Sampler(_),
+            | Type::Sampler(_)
+            | Type::Unknown,
             _,
         ) => Err(E::NotConstructible(ty.clone())),
         #[cfg(feature = "naga-ext")]

--- a/crates/wgsl-types/src/display.rs
+++ b/crates/wgsl-types/src/display.rs
@@ -189,6 +189,7 @@ impl Display for Type {
             Type::Ref(a_s, ty, a_m) => write!(f, "ref<{a_s}, {ty}, {a_m}>"),
             Type::Texture(texture_type) => texture_type.fmt(f),
             Type::Sampler(sampler_type) => sampler_type.fmt(f),
+            Type::Unknown => write!(f, "unknown"),
             #[cfg(feature = "naga-ext")]
             Type::I64 => write!(f, "i64"),
             #[cfg(feature = "naga-ext")]

--- a/crates/wgsl-types/src/idents.rs
+++ b/crates/wgsl-types/src/idents.rs
@@ -5,10 +5,12 @@
 ///
 /// Reference: <https://www.w3.org/TR/WGSL/#predeclared-types>
 pub const BUILTIN_TYPE_NAMES: &[&str] = &[
-    // abstract types cannot be spelled in user code.
+    // types that cannot be spelled in user code.
     // they are prefixed with `__`, which is not a valid WGSL identifier prefix.
     "__AbstractInt",
     "__AbstractFloat",
+    "__ref",
+    "__unknown",
     // plain types
     "bool",
     "f16",

--- a/crates/wgsl-types/src/mem.rs
+++ b/crates/wgsl-types/src/mem.rs
@@ -169,7 +169,11 @@ impl Instance {
                 };
                 Some(AtomicInstance::new(inst).into())
             }
-            Type::Ptr(_, _, _) | Type::Ref(_, _, _) | Type::Texture(_) | Type::Sampler(_) => None,
+            Type::Ptr(_, _, _)
+            | Type::Ref(_, _, _)
+            | Type::Texture(_)
+            | Type::Sampler(_)
+            | Type::Unknown => None,
             #[cfg(feature = "naga-ext")]
             Type::RayQuery(_) | Type::AccelerationStructure(_) => None,
         }
@@ -346,7 +350,11 @@ impl Type {
                 Some(*c as u32 * align)
             }
             Type::Atomic(_) => Some(4),
-            Type::Ptr(_, _, _) | Type::Ref(_, _, _) | Type::Texture(_) | Type::Sampler(_) => None,
+            Type::Ptr(_, _, _)
+            | Type::Ref(_, _, _)
+            | Type::Texture(_)
+            | Type::Sampler(_)
+            | Type::Unknown => None,
             #[cfg(feature = "naga-ext")]
             Type::RayQuery(_) | Type::AccelerationStructure(_) => None,
         }
@@ -405,7 +413,11 @@ impl Type {
             }
             Type::Mat(_, r, ty) => Type::Vec(*r, ty.clone()).align_of(),
             Type::Atomic(_) => Some(4),
-            Type::Ptr(_, _, _) | Type::Ref(_, _, _) | Type::Texture(_) | Type::Sampler(_) => None,
+            Type::Ptr(_, _, _)
+            | Type::Ref(_, _, _)
+            | Type::Texture(_)
+            | Type::Sampler(_)
+            | Type::Unknown => None,
             #[cfg(feature = "naga-ext")]
             Type::RayQuery(_) | Type::AccelerationStructure(_) => None,
         }

--- a/crates/wgsl-types/src/ty.rs
+++ b/crates/wgsl-types/src/ty.rs
@@ -269,6 +269,8 @@ pub enum Type {
     Ref(AddressSpace, Box<Type>, AccessMode),
     Texture(TextureType),
     Sampler(SamplerType),
+    /// This variant is used by wgsl-analyzer and other type-checking tools when
+    /// a type is unknown. It is not an regular WGSL type.
     Unknown,
     #[cfg(feature = "naga-ext")]
     I64,

--- a/crates/wgsl-types/src/ty.rs
+++ b/crates/wgsl-types/src/ty.rs
@@ -269,6 +269,7 @@ pub enum Type {
     Ref(AddressSpace, Box<Type>, AccessMode),
     Texture(TextureType),
     Sampler(SamplerType),
+    Unknown,
     #[cfg(feature = "naga-ext")]
     I64,
     #[cfg(feature = "naga-ext")]
@@ -346,7 +347,10 @@ impl Type {
     }
 
     pub fn is_concrete(&self) -> bool {
-        !self.is_abstract()
+        match self {
+            Type::Unknown => false,
+            _ => !self.is_abstract(),
+        }
     }
 
     /// Reference: <https://www.w3.org/TR/WGSL/#storable-types>
@@ -463,6 +467,7 @@ impl Ty for Type {
             Type::Ref(_, ty, _) => ty.ty(),
             Type::Texture(_) => self.clone(),
             Type::Sampler(_) => self.clone(),
+            Type::Unknown => self.clone(),
             #[cfg(feature = "naga-ext")]
             Type::I64 => self.clone(),
             #[cfg(feature = "naga-ext")]


### PR DESCRIPTION
This adds an unknown type for wgsl-analyzer. It avoids doing any bigger changes, like making the unknown type infectious.

Also, with #211 it's much more fun to work on wesl-rs :D