### PR TITLE
Blocks preceded by `@if` are flattened

### DIFF
--- a/crates/wesl-test/spec-tests/condcomp-flatten.json
+++ b/crates/wesl-test/spec-tests/condcomp-flatten.json
@@ -1,6 +1,6 @@
 [
 	{
-		"name": "module-compound",
+		"name": "module-compound-if-true",
 		"weslSrc": {
 			"./main.wgsl": "fn f() {} @if(true) { const_assert true; fn foo() {} struct bar { x: u32 } }"
 		},
@@ -8,12 +8,116 @@
 		"underscoreWgsl": "fn f() {} const_assert true; fn foo() {} struct bar { x: u32 }"
 	},
 	{
-		"name": "module-compound-nested",
+		"name": "module-compound-if-false",
 		"weslSrc": {
-			"./main.wgsl": "@if(true) { fn foo() {} { @if(true) fn bar() {} } @if(true) { fn baz() {} } }"
+			"./main.wgsl": "fn f() {} @if(false) { const_assert true; fn foo() {} struct bar { x: u32 } }"
 		},
-		"expectedWgsl": "fn foo() {} fn baz() {}",
-		"underscoreWgsl": "fn foo() {} fn baz() {}"
+		"expectedWgsl": "fn f() {}",
+		"underscoreWgsl": "fn f() {}"
+	},
+	{
+		"name": "module-compound-if-false-compound-elif-true",
+		"weslSrc": {
+			"./main.wgsl": "@if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; }"
+		},
+		"expectedWgsl": "const bar: u32 = 0;",
+		"underscoreWgsl": "const bar: u32 = 0;"
+	},
+	{
+		"name": "module-compound-if-true-compound-elif-true",
+		"weslSrc": {
+			"./main.wgsl": "@if(true) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; }"
+		},
+		"expectedWgsl": "const foo: u32 = 0;",
+		"underscoreWgsl": "const foo: u32 = 0;"
+	},
+	{
+		"name": "module-if-false-compound-elif-true",
+		"weslSrc": {
+			"./main.wgsl": "@if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; }"
+		},
+		"expectedWgsl": "const bar: u32 = 0;",
+		"underscoreWgsl": "const bar: u32 = 0;"
+	},
+	{
+		"name": "module-if-true-compound-elif-true",
+		"weslSrc": {
+			"./main.wgsl": "@if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; }"
+		},
+		"expectedWgsl": "const foo: u32 = 0;",
+		"underscoreWgsl": "const foo: u32 = 0;"
+	},
+	{
+		"name": "module-compound-else-hit",
+		"weslSrc": {
+			"./main.wgsl": "@if(false) { const foo: u32 = 0; } @elif(false) { const bar: u32 = 0; } @else { const baz: u32 = 0; }"
+		},
+		"expectedWgsl": "const baz: u32 = 0;",
+		"underscoreWgsl": "const baz: u32 = 0;"
+	},
+	{
+		"name": "module-compound-else-skipped",
+		"weslSrc": {
+			"./main.wgsl": "@if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } @else { const baz: u32 = 0; }"
+		},
+		"expectedWgsl": "const bar: u32 = 0;",
+		"underscoreWgsl": "const bar: u32 = 0;"
+	},
+	{
+		"name": "module-compound-noop",
+		"weslSrc": {
+			"./main.wgsl": "{ fn foo() {} }"
+		},
+		"expectedWgsl": "",
+		"underscoreWgsl": ""
+	},
+	{
+		"name": "module-compound-nested-noop",
+		"weslSrc": {
+			"./main.wgsl": "@if (true) { fn foo() {} { @if(true) fn bar() {} } }"
+		},
+		"expectedWgsl": "fn foo() {}",
+		"underscoreWgsl": "fn foo() {}"
+	},
+	{
+		"name": "module-compound-nested-if",
+		"weslSrc": {
+			"./main.wgsl": "@if(true) { fn foo() {} @if(true) { fn bar() {} } }"
+		},
+		"expectedWgsl": "fn foo() {} fn bar() {}",
+		"underscoreWgsl": "fn foo() {} fn bar() {}"
+	},
+	{
+		"name": "module-compound-nested-elif-hit",
+		"weslSrc": {
+			"./main.wgsl": "@if(true) { @if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; }"
+		},
+		"expectedWgsl": "const bar: u32 = 0;",
+		"underscoreWgsl": "const bar: u32 = 0;"
+	},
+	{
+		"name": "module-compound-nested-elif-skipped",
+		"weslSrc": {
+			"./main.wgsl": "@if(true) { @if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; }"
+		},
+		"expectedWgsl": "const foo: u32 = 0;",
+		"underscoreWgsl": "const foo: u32 = 0;"
+	},
+	{
+		"name": "module-compound-nested-else-hit",
+		"weslSrc": {
+			"./main.wgsl": "@if(true) { @if(false) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; }"
+		},
+		"expectedWgsl": "const bar: u32 = 0;",
+		"underscoreWgsl": "const bar: u32 = 0;"
+	},
+	{
+		"name": "module-compound-nested-else-skipped",
+		"weslSrc": {
+			"./main.wgsl": "@if(true) { @if(true) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; }"
+		},
+		"expectedWgsl": "const foo: u32 = 0;",
+		"underscoreWgsl": "const foo: u32 = 0;"
 	},
 	{
 		"name": "module-compound-shadow",
@@ -24,19 +128,107 @@
 		"underscoreWgsl": "const foo: u32 = 1;"
 	},
 	{
-		"name": "function-compound",
+		"name": "function-compound-if-true",
 		"weslSrc": {
-			"./main.wgsl": "fn foo() { @if(true) { var x = 0; } x++; }"
+			"./main.wgsl": "fn f() { @if(true) { const_assert true; const x: u32 = 0; } }"
 		},
-		"expectedWgsl": "fn foo() { var x = 0; x++; }",
-		"underscoreWgsl": "fn foo() { var x = 0; x++; }"
+		"expectedWgsl": "fn f() { const_assert true; const x: u32 = 0; }",
+		"underscoreWgsl": "fn f() { const_assert true; const x: u32 = 0; }"
 	},
 	{
-		"name": "function-compound-nested",
+		"name": "function-compound-if-false",
 		"weslSrc": {
-			"./main.wgsl": "fn foo() { @if(true) { var x = 0; { @if(true) x++; } @if(true) { x--; } } }"
+			"./main.wgsl": "fn f() { @if(false) { const_assert true; const x: u32 = 0; } }"
 		},
-		"expectedWgsl": "fn foo() { var x = 0; { x++; } x--; }",
-		"underscoreWgsl": "fn foo() { var x = 0; { x++; } x--; }"
+		"expectedWgsl": "fn f() {}",
+		"underscoreWgsl": "fn f() {}"
+	},
+	{
+		"name": "function-compound-if-false-compound-elif-true",
+		"weslSrc": {
+			"./main.wgsl": "fn f() { @if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } }"
+		},
+		"expectedWgsl": "fn f() { const bar: u32 = 0; }",
+		"underscoreWgsl": "fn f() { const bar: u32 = 0; }"
+	},
+	{
+		"name": "function-compound-if-true-compound-elif-true",
+		"weslSrc": {
+			"./main.wgsl": "fn f() { @if(true) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } }"
+		},
+		"expectedWgsl": "fn f() { const foo: u32 = 0; }",
+		"underscoreWgsl": "fn f() { const foo: u32 = 0; }"
+	},
+	{
+		"name": "function-if-false-compound-elif-true",
+		"weslSrc": {
+			"./main.wgsl": "fn f() { @if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } }"
+		},
+		"expectedWgsl": "fn f() { const bar: u32 = 0; }",
+		"underscoreWgsl": "fn f() { const bar: u32 = 0; }"
+	},
+	{
+		"name": "function-if-true-compound-elif-true",
+		"weslSrc": {
+			"./main.wgsl": "fn f() { @if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } }"
+		},
+		"expectedWgsl": "fn f() { const foo: u32 = 0; }",
+		"underscoreWgsl": "fn f() { const foo: u32 = 0; }"
+	},
+	{
+		"name": "function-compound-else-hit",
+		"weslSrc": {
+			"./main.wgsl": "fn f() { @if(false) { const foo: u32 = 0; } @elif(false) { const bar: u32 = 0; } @else { const baz: u32 = 0; } }"
+		},
+		"expectedWgsl": "fn f() { const baz: u32 = 0; }",
+		"underscoreWgsl": "fn f() { const baz: u32 = 0; }"
+	},
+	{
+		"name": "function-compound-else-skipped",
+		"weslSrc": {
+			"./main.wgsl": "fn f() { @if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } @else { const baz: u32 = 0; } }"
+		},
+		"expectedWgsl": "fn f() { const bar: u32 = 0; }",
+		"underscoreWgsl": "fn f() { const bar: u32 = 0; }"
+	},
+	{
+		"name": "function-compound-nested-if",
+		"weslSrc": {
+			"./main.wgsl": "fn f() { @if(true) { const foo: u32 = 0; @if(true) { const bar: u32 = 0; } } }"
+		},
+		"expectedWgsl": "fn f() { const foo: u32 = 0; const bar: u32 = 0; }",
+		"underscoreWgsl": "fn f() { const foo: u32 = 0; const bar: u32 = 0; }"
+	},
+	{
+		"name": "function-compound-nested-elif-hit",
+		"weslSrc": {
+			"./main.wgsl": "fn f() { @if(true) { @if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }"
+		},
+		"expectedWgsl": "fn f() { const bar: u32 = 0; }",
+		"underscoreWgsl": "fn f() { const bar: u32 = 0; }"
+	},
+	{
+		"name": "function-compound-nested-elif-skipped",
+		"weslSrc": {
+			"./main.wgsl": "fn f() { @if(true) { @if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }"
+		},
+		"expectedWgsl": "fn f() { const foo: u32 = 0; }",
+		"underscoreWgsl": "fn f() { const foo: u32 = 0; }"
+	},
+	{
+		"name": "function-compound-nested-else-hit",
+		"weslSrc": {
+			"./main.wgsl": "fn f() { @if(true) { @if(false) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }"
+		},
+		"expectedWgsl": "fn f() { const bar: u32 = 0; }",
+		"underscoreWgsl": "fn f() { const bar: u32 = 0; }"
+	},
+	{
+		"name": "function-compound-nested-else-skipped",
+		"weslSrc": {
+			"./main.wgsl": "fn f() { @if(true) { @if(true) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }"
+		},
+		"expectedWgsl": "fn f() { const foo: u32 = 0; }",
+		"underscoreWgsl": "fn f() { const foo: u32 = 0; }"
 	}
 ]

--- a/crates/wesl-test/spec-tests/condcomp-flatten.json
+++ b/crates/wesl-test/spec-tests/condcomp-flatten.json
@@ -1,11 +1,19 @@
 [
     {
         "name": "allow-global-compound-declarations",
-        "desc": "allow module-scope compound declarations",
-        "kind": "syntax",
-        "syntax": "declaration",
-        "code": "fn f() {} @if(true) { const_assert true; fn foo() {} struct bar { x: u32 } }",
-        "expect": "pass"
+        "weslSrc": {
+          "./main.wgsl": "fn f() {} @if(true) { const_assert true; fn foo() {} struct bar { x: u32 } }"
+        },
+        "expectedWgsl": "fn f() {} const_assert true; fn foo() {} struct bar { x: u32 }",
+        "underscoreWgsl": "fn f() {} const_assert true; fn foo() {} struct bar { x: u32 }"
+    },
+    {
+        "name": "compound-decl-shadow",
+        "weslSrc": {
+          "./main.wgsl": "{ const foo: u32 = 0; } const foo: u32 = 1;"
+        },
+        "expectedWgsl": "const foo: u32 = 1;",
+        "underscoreWgsl": "const foo: u32 = 1;"
     }
 ]
 

--- a/crates/wesl-test/spec-tests/condcomp-flatten.json
+++ b/crates/wesl-test/spec-tests/condcomp-flatten.json
@@ -1,0 +1,11 @@
+[
+    {
+        "name": "allow-global-compound-declarations",
+        "desc": "allow module-scope compound declarations",
+        "kind": "syntax",
+        "syntax": "declaration",
+        "code": "fn f() {} @if(true) { const_assert true; fn foo() {} struct bar { x: u32 } }",
+        "expect": "pass"
+    }
+]
+

--- a/crates/wesl-test/spec-tests/condcomp-flatten.json
+++ b/crates/wesl-test/spec-tests/condcomp-flatten.json
@@ -1,19 +1,42 @@
 [
-    {
-        "name": "allow-global-compound-declarations",
-        "weslSrc": {
-          "./main.wgsl": "fn f() {} @if(true) { const_assert true; fn foo() {} struct bar { x: u32 } }"
-        },
-        "expectedWgsl": "fn f() {} const_assert true; fn foo() {} struct bar { x: u32 }",
-        "underscoreWgsl": "fn f() {} const_assert true; fn foo() {} struct bar { x: u32 }"
-    },
-    {
-        "name": "compound-decl-shadow",
-        "weslSrc": {
-          "./main.wgsl": "{ const foo: u32 = 0; } const foo: u32 = 1;"
-        },
-        "expectedWgsl": "const foo: u32 = 1;",
-        "underscoreWgsl": "const foo: u32 = 1;"
-    }
+	{
+		"name": "module-compound",
+		"weslSrc": {
+			"./main.wgsl": "fn f() {} @if(true) { const_assert true; fn foo() {} struct bar { x: u32 } }"
+		},
+		"expectedWgsl": "fn f() {} const_assert true; fn foo() {} struct bar { x: u32 }",
+		"underscoreWgsl": "fn f() {} const_assert true; fn foo() {} struct bar { x: u32 }"
+	},
+	{
+		"name": "module-compound-nested",
+		"weslSrc": {
+			"./main.wgsl": "@if(true) { fn foo() {} { @if(true) fn bar() {} } @if(true) { fn baz() {} } }"
+		},
+		"expectedWgsl": "fn foo() {} fn baz() {}",
+		"underscoreWgsl": "fn foo() {} fn baz() {}"
+	},
+	{
+		"name": "module-compound-shadow",
+		"weslSrc": {
+			"./main.wgsl": "{ const foo: u32 = 0; } const foo: u32 = 1;"
+		},
+		"expectedWgsl": "const foo: u32 = 1;",
+		"underscoreWgsl": "const foo: u32 = 1;"
+	},
+	{
+		"name": "function-compound",
+		"weslSrc": {
+			"./main.wgsl": "fn foo() { @if(true) { var x = 0; } x++; }"
+		},
+		"expectedWgsl": "fn foo() { var x = 0; x++; }",
+		"underscoreWgsl": "fn foo() { var x = 0; x++; }"
+	},
+	{
+		"name": "function-compound-nested",
+		"weslSrc": {
+			"./main.wgsl": "fn foo() { @if(true) { var x = 0; { @if(true) x++; } @if(true) { x--; } } }"
+		},
+		"expectedWgsl": "fn foo() { var x = 0; { x++; } x--; }",
+		"underscoreWgsl": "fn foo() { var x = 0; { x++; } x--; }"
+	}
 ]
-

--- a/crates/wesl-test/spec-tests/dead-code.json
+++ b/crates/wesl-test/spec-tests/dead-code.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "strip-unused-declaration",
+        "name": "strip-import-unused-declaration",
         "weslSrc": {
             "./main.wgsl": "import package::m1::foo; fn main() { foo(); }",
             "./m1.wgsl": "fn foo() { } fn bar() { }"
@@ -9,7 +9,16 @@
         "underscoreWgsl": "fn main() { package_m1_foo(); } fn package_m1_foo() { }"
     },
     {
-        "name": "strip-unused-module",
+        "name": "strip-import-const-asserts-if-module-unused",
+        "weslSrc": {
+            "./main.wgsl": "import package::m1::unused; fn main() { }",
+            "./m1.wgsl": "const_assert true; fn foo() { } fn unused() { }"
+        },
+        "expectedWgsl": "fn main() { }",
+        "underscoreWgsl": "fn main() { }"
+    },
+    {
+        "name": "strip-deep-import-unused-module",
         "weslSrc": {
             "./main.wgsl": "import package::m1::foo; fn main() { foo(); }",
             "./m1.wgsl": "import package::m2::bar; fn foo() { } fn unused() { bar(); }",
@@ -19,12 +28,29 @@
         "underscoreWgsl": "fn main() { package_m1_foo(); } fn package_m1_foo() { }"
     },
     {
-        "name": "keep-const-asserts",
+        "name": "keep-import-const-asserts-if-module-used",
         "weslSrc": {
             "./main.wgsl": "import package::m1::foo; fn main() { foo(); }",
             "./m1.wgsl": "const_assert true; fn foo() { } fn bar() { }"
         },
-        "expectedWgsl": "fn main() { foo(); } fn foo() { }",
+        "expectedWgsl": "fn main() { foo(); } const_assert true; fn foo() { }",
+        "underscoreWgsl": "fn main() { package_m1_foo(); } const_assert true; fn package_m1_foo() { }"
+    },
+    {
+        "name": "strip-compound-decl",
+        "weslSrc": {
+            "./main.wgsl": "{ fn foo() {} } fn main() { }"
+        },
+        "expectedWgsl": "fn main() { }",
+        "underscoreWgsl": "fn main() { }"
+    },
+    {
+        "name": "keep-used-compound-decl",
+        "weslSrc": {
+            "./main.wgsl": "import package::m1::foo; fn main() { foo(); }",
+            "./m1.wgsl": "@if (true) { const_assert true; fn foo() {} fn bar() {} }"
+        },
+        "expectedWgsl": "fn main() { foo(); } const_assert true; fn foo() { }",
         "underscoreWgsl": "fn main() { package_m1_foo(); } const_assert true; fn package_m1_foo() { }"
     }
 ]

--- a/crates/wesl-test/tests/testsuite.rs
+++ b/crates/wesl-test/tests/testsuite.rs
@@ -57,7 +57,6 @@ fn main() {
         "spec-tests/imports.json",
         "spec-tests/circular.json",
         "spec-tests/types.json",
-        "spec-tests/condcomp-flatten.json",
     ];
     for path in spec_tests {
         tests.extend({
@@ -100,6 +99,7 @@ fn main() {
         "wesl-testsuite/src/test-cases-json/importCases.json",
         "wesl-testsuite/src/test-cases-json/conditionalTranslationCases.json",
         "spec-tests/dead-code.json",
+        "spec-tests/condcomp-flatten.json",
     ];
     for path in testsuite_tests {
         tests.extend({

--- a/crates/wesl-test/tests/testsuite.rs
+++ b/crates/wesl-test/tests/testsuite.rs
@@ -108,9 +108,11 @@ fn main() {
                 serde_json::from_str(&file).expect("failed to parse json file");
             json.into_iter().map(|case| {
                 let name = format!("importCases.json::{}", case.name);
+                let ignored = case.name == "@else with package function reference"; // TODO: update this test in the testsuite, it does not flatten @if
                 libtest_mimic::Trial::test(name, move || {
                     testsuite_case(&case).inspect_err(|_| eprint_wgsl_test(&case))
                 })
+                .with_ignored_flag(ignored)
             })
         });
     }

--- a/crates/wesl-test/tests/testsuite.rs
+++ b/crates/wesl-test/tests/testsuite.rs
@@ -57,6 +57,7 @@ fn main() {
         "spec-tests/imports.json",
         "spec-tests/circular.json",
         "spec-tests/types.json",
+        "spec-tests/condcomp-flatten.json",
     ];
     for path in spec_tests {
         tests.extend({
@@ -466,14 +467,24 @@ pub fn bevy_case(path: PathBuf) -> Result<(), libtest_mimic::Failed> {
 fn sort_decls(wgsl: &mut TranslationUnit) {
     use std::cmp::Ordering;
     type Decl = GlobalDeclaration;
-    wgsl.global_declarations
-        .sort_unstable_by(|a, b| match (a.node(), b.node()) {
+
+    fn sort_fn(a: &GlobalDeclaration, b: &GlobalDeclaration) -> Ordering {
+        match (a, b) {
             (Decl::Void, Decl::Void) => Ordering::Equal,
             (Decl::Void, Decl::Declaration(_)) => Ordering::Less,
             (Decl::Void, Decl::Struct(_)) => Ordering::Less,
             (Decl::Void, Decl::TypeAlias(_)) => Ordering::Less,
             (Decl::Void, Decl::ConstAssert(_)) => Ordering::Less,
             (Decl::Void, Decl::Function(_)) => Ordering::Less,
+            (Decl::Void, Decl::Compound(_)) => Ordering::Less,
+
+            (Decl::Compound(_), Decl::Void) => Ordering::Greater,
+            (Decl::Compound(_), Decl::Declaration(_)) => Ordering::Greater,
+            (Decl::Compound(_), Decl::Struct(_)) => Ordering::Greater,
+            (Decl::Compound(_), Decl::TypeAlias(_)) => Ordering::Greater,
+            (Decl::Compound(_), Decl::ConstAssert(_)) => Ordering::Greater,
+            (Decl::Compound(_), Decl::Function(_)) => Ordering::Greater,
+            (Decl::Compound(_), Decl::Compound(_)) => Ordering::Equal,
 
             (Decl::Declaration(_), Decl::Void) => Ordering::Greater,
             (Decl::Declaration(d1), Decl::Declaration(d2)) => d1.ident.name().cmp(&d2.ident.name()),
@@ -481,6 +492,7 @@ fn sort_decls(wgsl: &mut TranslationUnit) {
             (Decl::Declaration(_), Decl::TypeAlias(_)) => Ordering::Less,
             (Decl::Declaration(_), Decl::ConstAssert(_)) => Ordering::Less,
             (Decl::Declaration(_), Decl::Function(_)) => Ordering::Less,
+            (Decl::Declaration(_), Decl::Compound(_)) => Ordering::Less,
 
             (Decl::Struct(_), Decl::Void) => Ordering::Greater,
             (Decl::Struct(_), Decl::Declaration(_)) => Ordering::Greater,
@@ -488,6 +500,7 @@ fn sort_decls(wgsl: &mut TranslationUnit) {
             (Decl::Struct(_), Decl::TypeAlias(_)) => Ordering::Less,
             (Decl::Struct(_), Decl::ConstAssert(_)) => Ordering::Less,
             (Decl::Struct(_), Decl::Function(_)) => Ordering::Less,
+            (Decl::Struct(_), Decl::Compound(_)) => Ordering::Less,
 
             (Decl::TypeAlias(_), Decl::Void) => Ordering::Greater,
             (Decl::TypeAlias(_), Decl::Declaration(_)) => Ordering::Greater,
@@ -495,6 +508,7 @@ fn sort_decls(wgsl: &mut TranslationUnit) {
             (Decl::TypeAlias(d1), Decl::TypeAlias(d2)) => d1.ident.name().cmp(&d2.ident.name()),
             (Decl::TypeAlias(_), Decl::ConstAssert(_)) => Ordering::Less,
             (Decl::TypeAlias(_), Decl::Function(_)) => Ordering::Less,
+            (Decl::TypeAlias(_), Decl::Compound(_)) => Ordering::Less,
 
             (Decl::ConstAssert(_), Decl::Void) => Ordering::Greater,
             (Decl::ConstAssert(_), Decl::Declaration(_)) => Ordering::Greater,
@@ -502,6 +516,7 @@ fn sort_decls(wgsl: &mut TranslationUnit) {
             (Decl::ConstAssert(_), Decl::TypeAlias(_)) => Ordering::Greater,
             (Decl::ConstAssert(_), Decl::ConstAssert(_)) => Ordering::Equal,
             (Decl::ConstAssert(_), Decl::Function(_)) => Ordering::Less,
+            (Decl::ConstAssert(_), Decl::Compound(_)) => Ordering::Less,
 
             (Decl::Function(_), Decl::Void) => Ordering::Greater,
             (Decl::Function(_), Decl::Declaration(_)) => Ordering::Greater,
@@ -509,5 +524,10 @@ fn sort_decls(wgsl: &mut TranslationUnit) {
             (Decl::Function(_), Decl::TypeAlias(_)) => Ordering::Greater,
             (Decl::Function(_), Decl::ConstAssert(_)) => Ordering::Greater,
             (Decl::Function(d1), Decl::Function(d2)) => d1.ident.name().cmp(&d2.ident.name()),
-        });
+            (Decl::Function(_), Decl::Compound(_)) => Ordering::Less,
+        }
+    }
+
+    wgsl.global_declarations
+        .sort_unstable_by(|a, b| sort_fn(a.node(), b.node()));
 }

--- a/crates/wesl/src/condcomp.rs
+++ b/crates/wesl/src/condcomp.rs
@@ -366,13 +366,43 @@ fn stmt_eval_if_attrs(statements: &mut Vec<StatementNode>, features: &Features) 
         };
         Ok(())
     }
+
     fn rec(stats: &mut Vec<StatementNode>, feats: &Features) -> Result<PrevEval, E> {
-        let prev = eval_if_attrs(stats, feats)?;
+        let mut prev = PrevEval {
+            has_if: false,
+            is_true: false,
+            removed: false,
+        };
+
+        // If an `@if` decorates a compound statement, the statement gets flattened.
+        // This is the same code as in eval_if_attrs, except it flattens the compound when it evaluates to true.
+        {
+            let mut i = 0;
+
+            // remove the nodes for which the attr evaluate to false.
+            while let Some(node) = stats.get_mut(i) {
+                eval_if_attr(node, &mut prev, feats)?;
+                if let Statement::Compound(stmt) = &**node
+                    && prev.is_true
+                {
+                    // replace the compound statements with its contents
+                    // TODO: other compound statement attributes are lost. validation has no opportunity to check them.
+                    // COMBAK: this clone is unnecessary and probably inefficient.
+                    let body = stmt.statements.clone();
+                    stats.splice(i..i + 1, body);
+                } else if prev.removed {
+                    stats.remove(i);
+                }
+                i += 1;
+            }
+        }
+
         for stmt in stats {
             rec_one(stmt, feats)?;
         }
         Ok(prev)
     }
+
     rec(statements, features).map(|_| ())
 }
 

--- a/crates/wesl/src/condcomp.rs
+++ b/crates/wesl/src/condcomp.rs
@@ -321,7 +321,7 @@ fn eval_if_attrs(nodes: &mut Vec<impl SyntaxNode>, features: &Features) -> Resul
 }
 
 fn stmt_eval_if_attrs(statements: &mut Vec<StatementNode>, features: &Features) -> Result<(), E> {
-    fn rec_one(stmt: &mut StatementNode, feats: &Features) -> Result<(), E> {
+    fn rec_eval_inside_stmt(stmt: &mut StatementNode, feats: &Features) -> Result<(), E> {
         match stmt.node_mut() {
             Statement::Compound(stmt) => {
                 rec(&mut stmt.statements, feats)?;
@@ -352,10 +352,10 @@ fn stmt_eval_if_attrs(statements: &mut Vec<StatementNode>, features: &Features) 
             }
             Statement::For(stmt) => {
                 if let Some(init) = &mut stmt.initializer {
-                    rec_one(&mut *init, feats)?
+                    rec_eval_inside_stmt(&mut *init, feats)?
                 }
                 if let Some(updt) = &mut stmt.update {
-                    rec_one(&mut *updt, feats)?
+                    rec_eval_inside_stmt(&mut *updt, feats)?
                 }
                 rec(&mut stmt.body.statements, feats)?;
             }
@@ -383,26 +383,26 @@ fn stmt_eval_if_attrs(statements: &mut Vec<StatementNode>, features: &Features) 
             while let Some(node) = stmts.get_mut(i) {
                 eval_if_attr(node, &mut prev, feats)?;
                 if let Statement::Compound(stmt) = &**node
-                    && prev.is_true && !prev.removed
+                    && prev.is_true
+                    && !prev.removed
                 {
                     // replace the compound statements with its contents
                     // TODO: other compound statement attributes are lost. validation has no opportunity to check them.
                     // COMBAK: this clone is unnecessary and probably inefficient.
-                    let body = stmt.statements.clone();
+                    let mut body = stmt.statements.clone();
+                    rec(&mut body, feats)?;
                     let n = body.len();
                     stmts.splice(i..i + 1, body);
                     i += n;
                 } else if prev.removed {
                     stmts.remove(i);
                 } else {
+                    rec_eval_inside_stmt(node, feats)?;
                     i += 1;
                 }
             }
         }
 
-        for stmt in stmts {
-            rec_one(stmt, feats)?;
-        }
         Ok(prev)
     }
 
@@ -416,7 +416,10 @@ pub fn run(wesl: &mut TranslationUnit, features: &Features) -> Result<(), E> {
 
     // If an `@if` decorates a compound global declaration, it gets flattened.
     // This is the same code as in eval_if_attrs, except it flattens the compound when it evaluates to true.
-    {
+    fn eval_flatten_compound(
+        decls: &mut Vec<GlobalDeclarationNode>,
+        features: &Features,
+    ) -> Result<(), E> {
         let mut prev = PrevEval {
             has_if: false,
             is_true: false,
@@ -426,25 +429,31 @@ pub fn run(wesl: &mut TranslationUnit, features: &Features) -> Result<(), E> {
         let mut i = 0;
 
         // remove the nodes for which the attr evaluate to false.
-        while let Some(node) = wesl.global_declarations.get_mut(i) {
+        while let Some(node) = decls.get_mut(i) {
             eval_if_attr(node, &mut prev, features)?;
             if let GlobalDeclaration::Compound(stmt) = &**node
-                && prev.is_true && !prev.removed
+                && prev.is_true
+                && !prev.removed
             {
                 // replace the compound statements with its contents
                 // TODO: other compound statement attributes are lost. validation has no opportunity to check them.
                 // COMBAK: this clone is unnecessary and probably inefficient.
-                let body = stmt.body.clone();
+                let mut body = stmt.body.clone();
+                eval_flatten_compound(&mut body, features)?;
                 let n = body.len();
-                wesl.global_declarations.splice(i..i + 1, body);
+                decls.splice(i..i + 1, body);
                 i += n;
             } else if prev.removed {
-                wesl.global_declarations.remove(i);
+                decls.remove(i);
             } else {
                 i += 1;
             }
         }
+
+        Ok(())
     }
+
+    eval_flatten_compound(&mut wesl.global_declarations, features)?;
 
     for decl in &mut wesl.global_declarations {
         if let GlobalDeclaration::Struct(decl) = decl.node_mut() {

--- a/crates/wesl/src/condcomp.rs
+++ b/crates/wesl/src/condcomp.rs
@@ -183,11 +183,17 @@ fn get_single_attr(attrs: &mut [AttributeNode]) -> Result<Option<&mut AttributeN
     }
 }
 
+/// Conditional state of a syntax node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct PrevEval {
-    has_if: bool,
-    is_true: bool,
-    removed: bool,
+struct NodeEval {
+    /// Whether the syntax node has an if, elif or else attribute.
+    has_condcomp: bool,
+    /// Whether the node evaluates to false and is removed.
+    /// e.g. `@if(false)` or `@if(true) ... @else`
+    is_false: bool,
+    /// Whether this node, or a previous node in the if/elif chain, evaluates to true.
+    /// All following elif/else nodes in the chain therefore evaluate to false.
+    chain_has_true: bool,
 }
 
 /// * ensure there is at most one if/elif/else node.
@@ -197,7 +203,7 @@ struct PrevEval {
 /// * turn elifs into elses when it evaluates to true.
 fn eval_if_attr(
     node: &mut impl SyntaxNode,
-    prev: &mut PrevEval,
+    prev: &mut NodeEval,
     features: &Features,
 ) -> Result<(), E> {
     let span = node.span();
@@ -212,62 +218,61 @@ fn eval_if_attr(
 
 fn eval_if_attr_impl(
     node: &mut impl SyntaxNode,
-    prev: &mut PrevEval,
+    prev: &mut NodeEval,
     features: &Features,
 ) -> Result<(), E> {
     let attr = get_single_attr(node.attributes_mut())?;
     if let Some(attr) = attr {
-        let mut has_if = false;
+        prev.has_condcomp = attr.is_condcomp();
         if let Attribute::If(expr) = attr.node_mut() {
             **expr = eval_attr(expr, features)?;
-            has_if = true;
-            prev.is_true = false;
+            // a new `if` starts a new if/elif/else chain
+            prev.chain_has_true = false;
         } else if let Attribute::Elif(expr) = attr.node_mut() {
-            if !prev.has_if {
+            if !prev.has_condcomp {
                 return Err(CondCompError::NoPrecedingIf.into());
             } else {
                 **expr = eval_attr(expr, features)?;
-                has_if = true;
             }
         } else if let Attribute::Else = attr.node()
-            && !prev.has_if
+            && !prev.has_condcomp
         {
             return Err(CondCompError::NoPrecedingIf.into());
         }
-        prev.has_if = has_if;
     } else {
-        prev.has_if = false;
+        prev.has_condcomp = false;
     }
 
-    let mut remove_node = false;
-    let mut remove_attr = false;
-    let mut is_true = false;
+    let mut is_false = false;
+
     node.retain_attributes_mut(|attr| {
+        let mut remove_attr = false;
         if let Attribute::If(expr) = attr {
             if **expr == EXPR_TRUE {
-                remove_attr = true; // if(true) => remove the attribute
-                is_true = true;
+                remove_attr = true;
+                prev.chain_has_true = true;
             } else if **expr == EXPR_FALSE {
-                remove_node = true; // if(false) => remove the node
+                is_false = true;
             }
         } else if let Attribute::Elif(expr) = attr {
-            if prev.is_true || **expr == EXPR_FALSE {
-                remove_node = true;
+            if prev.chain_has_true || **expr == EXPR_FALSE {
+                is_false = true; // a previous node was chosen, delete the whole node
             } else if **expr == EXPR_TRUE {
-                is_true = true;
-                if prev.removed {
-                    remove_attr = true;
+                if prev.is_false {
+                    remove_attr = true; // the previous node is false and is deleted, so elif(true) can be removed
                 } else {
-                    *attr = Attribute::Else;
+                    *attr = Attribute::Else; // the previous node is undecided, but elif(true) can become else.
                 }
-            } else if prev.removed {
-                *attr = Attribute::If(expr.clone()); // previous node was deleted, make this an if
+                prev.chain_has_true = true;
+            } else if prev.is_false {
+                *attr = Attribute::If(expr.clone()); // the previous node is false and is deleted, elif becomes if
             }
         } else if let Attribute::Else = attr {
-            if prev.is_true {
-                remove_node = true; // previous node was chosen, delete the whole node
-            } else if prev.removed {
-                remove_attr = true; // previous node was deleted, delete this attribute
+            if prev.chain_has_true {
+                is_false = true; // a previous node was chosen, delete the whole node
+            } else if prev.is_false {
+                remove_attr = true; // the previous node was deleted, delete this attribute
+                prev.chain_has_true = true;
             }
         } else {
             // we keep non-condcomp attributes
@@ -277,30 +282,29 @@ fn eval_if_attr_impl(
         !remove_attr
     });
 
-    prev.is_true = is_true || prev.is_true;
-    prev.removed = remove_node;
+    prev.is_false = is_false;
     Ok(())
 }
 
 fn eval_opt_attr(
     opt_node: &mut Option<impl SyntaxNode>,
-    prev: &mut PrevEval,
+    prev: &mut NodeEval,
     features: &Features,
 ) -> Result<(), E> {
     if let Some(node) = opt_node {
         eval_if_attr(node, prev, features)?;
-        if prev.removed {
+        if prev.chain_has_true && !prev.is_false {
             *opt_node = None;
         }
     }
     Ok(())
 }
 
-fn eval_if_attrs(nodes: &mut Vec<impl SyntaxNode>, features: &Features) -> Result<PrevEval, E> {
-    let mut prev = PrevEval {
-        has_if: false,
-        is_true: false,
-        removed: false,
+fn eval_if_attrs(nodes: &mut Vec<impl SyntaxNode>, features: &Features) -> Result<NodeEval, E> {
+    let mut prev = NodeEval {
+        has_condcomp: false,
+        chain_has_true: false,
+        is_false: false,
     };
     let mut err = None;
 
@@ -310,7 +314,7 @@ fn eval_if_attrs(nodes: &mut Vec<impl SyntaxNode>, features: &Features) -> Resul
         if let (Err(e), None) = (res, &err) {
             err = Some(e);
         }
-        !prev.removed // keep the node if attr is unresolved or true.
+        !prev.is_false
     });
 
     if let Some(e) = err {
@@ -367,11 +371,11 @@ fn stmt_eval_if_attrs(statements: &mut Vec<StatementNode>, features: &Features) 
         Ok(())
     }
 
-    fn rec(stmts: &mut Vec<StatementNode>, feats: &Features) -> Result<PrevEval, E> {
-        let mut prev = PrevEval {
-            has_if: false,
-            is_true: false,
-            removed: false,
+    fn rec(stmts: &mut Vec<StatementNode>, feats: &Features) -> Result<NodeEval, E> {
+        let mut prev = NodeEval {
+            has_condcomp: false,
+            chain_has_true: false,
+            is_false: false,
         };
 
         // If an `@if` decorates a compound statement, the statement gets flattened.
@@ -383,8 +387,8 @@ fn stmt_eval_if_attrs(statements: &mut Vec<StatementNode>, features: &Features) 
             while let Some(node) = stmts.get_mut(i) {
                 eval_if_attr(node, &mut prev, feats)?;
                 if let Statement::Compound(stmt) = &**node
-                    && prev.is_true
-                    && !prev.removed
+                    && prev.has_condcomp
+                    && !prev.is_false
                 {
                     // replace the compound statements with its contents
                     // TODO: other compound statement attributes are lost. validation has no opportunity to check them.
@@ -394,7 +398,7 @@ fn stmt_eval_if_attrs(statements: &mut Vec<StatementNode>, features: &Features) 
                     let n = body.len();
                     stmts.splice(i..i + 1, body);
                     i += n;
-                } else if prev.removed {
+                } else if prev.is_false {
                     stmts.remove(i);
                 } else {
                     rec_eval_inside_stmt(node, feats)?;
@@ -420,10 +424,10 @@ pub fn run(wesl: &mut TranslationUnit, features: &Features) -> Result<(), E> {
         decls: &mut Vec<GlobalDeclarationNode>,
         features: &Features,
     ) -> Result<(), E> {
-        let mut prev = PrevEval {
-            has_if: false,
-            is_true: false,
-            removed: false,
+        let mut prev = NodeEval {
+            has_condcomp: false,
+            chain_has_true: false,
+            is_false: false,
         };
 
         let mut i = 0;
@@ -432,8 +436,8 @@ pub fn run(wesl: &mut TranslationUnit, features: &Features) -> Result<(), E> {
         while let Some(node) = decls.get_mut(i) {
             eval_if_attr(node, &mut prev, features)?;
             if let GlobalDeclaration::Compound(stmt) = &**node
-                && prev.is_true
-                && !prev.removed
+                && prev.has_condcomp
+                && !prev.is_false
             {
                 // replace the compound statements with its contents
                 // TODO: other compound statement attributes are lost. validation has no opportunity to check them.
@@ -443,7 +447,7 @@ pub fn run(wesl: &mut TranslationUnit, features: &Features) -> Result<(), E> {
                 let n = body.len();
                 decls.splice(i..i + 1, body);
                 i += n;
-            } else if prev.removed {
+            } else if prev.is_false {
                 decls.remove(i);
             } else {
                 i += 1;

--- a/crates/wesl/src/condcomp.rs
+++ b/crates/wesl/src/condcomp.rs
@@ -383,17 +383,20 @@ fn stmt_eval_if_attrs(statements: &mut Vec<StatementNode>, features: &Features) 
             while let Some(node) = stmts.get_mut(i) {
                 eval_if_attr(node, &mut prev, feats)?;
                 if let Statement::Compound(stmt) = &**node
-                    && prev.is_true
+                    && prev.is_true && !prev.removed
                 {
                     // replace the compound statements with its contents
                     // TODO: other compound statement attributes are lost. validation has no opportunity to check them.
                     // COMBAK: this clone is unnecessary and probably inefficient.
                     let body = stmt.statements.clone();
+                    let n = body.len();
                     stmts.splice(i..i + 1, body);
+                    i += n;
                 } else if prev.removed {
                     stmts.remove(i);
+                } else {
+                    i += 1;
                 }
-                i += 1;
             }
         }
 
@@ -426,17 +429,20 @@ pub fn run(wesl: &mut TranslationUnit, features: &Features) -> Result<(), E> {
         while let Some(node) = wesl.global_declarations.get_mut(i) {
             eval_if_attr(node, &mut prev, features)?;
             if let GlobalDeclaration::Compound(stmt) = &**node
-                && prev.is_true
+                && prev.is_true && !prev.removed
             {
                 // replace the compound statements with its contents
                 // TODO: other compound statement attributes are lost. validation has no opportunity to check them.
                 // COMBAK: this clone is unnecessary and probably inefficient.
                 let body = stmt.body.clone();
+                let n = body.len();
                 wesl.global_declarations.splice(i..i + 1, body);
+                i += n;
             } else if prev.removed {
                 wesl.global_declarations.remove(i);
+            } else {
+                i += 1;
             }
-            i += 1;
         }
     }
 

--- a/crates/wesl/src/condcomp.rs
+++ b/crates/wesl/src/condcomp.rs
@@ -367,7 +367,7 @@ fn stmt_eval_if_attrs(statements: &mut Vec<StatementNode>, features: &Features) 
         Ok(())
     }
 
-    fn rec(stats: &mut Vec<StatementNode>, feats: &Features) -> Result<PrevEval, E> {
+    fn rec(stmts: &mut Vec<StatementNode>, feats: &Features) -> Result<PrevEval, E> {
         let mut prev = PrevEval {
             has_if: false,
             is_true: false,
@@ -380,7 +380,7 @@ fn stmt_eval_if_attrs(statements: &mut Vec<StatementNode>, features: &Features) 
             let mut i = 0;
 
             // remove the nodes for which the attr evaluate to false.
-            while let Some(node) = stats.get_mut(i) {
+            while let Some(node) = stmts.get_mut(i) {
                 eval_if_attr(node, &mut prev, feats)?;
                 if let Statement::Compound(stmt) = &**node
                     && prev.is_true
@@ -389,15 +389,15 @@ fn stmt_eval_if_attrs(statements: &mut Vec<StatementNode>, features: &Features) 
                     // TODO: other compound statement attributes are lost. validation has no opportunity to check them.
                     // COMBAK: this clone is unnecessary and probably inefficient.
                     let body = stmt.statements.clone();
-                    stats.splice(i..i + 1, body);
+                    stmts.splice(i..i + 1, body);
                 } else if prev.removed {
-                    stats.remove(i);
+                    stmts.remove(i);
                 }
                 i += 1;
             }
         }
 
-        for stmt in stats {
+        for stmt in stmts {
             rec_one(stmt, feats)?;
         }
         Ok(prev)
@@ -410,7 +410,35 @@ pub fn run(wesl: &mut TranslationUnit, features: &Features) -> Result<(), E> {
     wesl.remove_voids();
     eval_if_attrs(&mut wesl.imports, features)?;
     eval_if_attrs(&mut wesl.global_directives, features)?;
-    eval_if_attrs(&mut wesl.global_declarations, features)?;
+
+    // If an `@if` decorates a compound global declaration, it gets flattened.
+    // This is the same code as in eval_if_attrs, except it flattens the compound when it evaluates to true.
+    {
+        let mut prev = PrevEval {
+            has_if: false,
+            is_true: false,
+            removed: false,
+        };
+
+        let mut i = 0;
+
+        // remove the nodes for which the attr evaluate to false.
+        while let Some(node) = wesl.global_declarations.get_mut(i) {
+            eval_if_attr(node, &mut prev, features)?;
+            if let GlobalDeclaration::Compound(stmt) = &**node
+                && prev.is_true
+            {
+                // replace the compound statements with its contents
+                // TODO: other compound statement attributes are lost. validation has no opportunity to check them.
+                // COMBAK: this clone is unnecessary and probably inefficient.
+                let body = stmt.body.clone();
+                wesl.global_declarations.splice(i..i + 1, body);
+            } else if prev.removed {
+                wesl.global_declarations.remove(i);
+            }
+            i += 1;
+        }
+    }
 
     for decl in &mut wesl.global_declarations {
         if let GlobalDeclaration::Struct(decl) = decl.node_mut() {

--- a/crates/wesl/src/eval/lower.rs
+++ b/crates/wesl/src/eval/lower.rs
@@ -587,6 +587,7 @@ impl Lower for TranslationUnit {
                 GlobalDeclaration::Struct(decl) => decl.lower(ctx),
                 GlobalDeclaration::Function(decl) => decl.lower(ctx),
                 GlobalDeclaration::ConstAssert(_) => Ok(()), // handled by TranslationUnit::exec()
+                GlobalDeclaration::Compound(_) => Ok(()),    // is a no-op
             }
             .inspect_err(|_| {
                 if let Some(ident) = decl.ident() {
@@ -601,6 +602,7 @@ impl Lower for TranslationUnit {
             GlobalDeclaration::Struct(_) => true,
             GlobalDeclaration::Function(_) => true,
             GlobalDeclaration::ConstAssert(_) => false,
+            GlobalDeclaration::Compound(_) => false,
         });
         Ok(())
     }

--- a/crates/wesl/src/syntax_util.rs
+++ b/crates/wesl/src/syntax_util.rs
@@ -346,6 +346,7 @@ impl SyntaxUtil for TranslationUnit {
                 GlobalDeclaration::Struct(decl) => Some(&mut decl.ident),
                 GlobalDeclaration::Function(decl) => Some(&mut decl.ident),
                 GlobalDeclaration::ConstAssert(_) => None,
+                GlobalDeclaration::Compound(_) => None,
             };
 
             if let Some(ident) = ident {
@@ -400,6 +401,13 @@ impl SyntaxUtil for TranslationUnit {
                 }
                 GlobalDeclaration::ConstAssert(d) => {
                     Visit::<TypeExpression>::visit_mut(d).for_each(|ty| retarget_ty(ty, &scope))
+                }
+                GlobalDeclaration::Compound(c) => {
+                    query_mut!(c.{
+                        attributes.[].(x => x.visit_mut()),
+                        body.[].(x => Visit::<TypeExpression>::visit_mut(&mut **x)),
+                    })
+                    .for_each(|ty| retarget_ty(ty, &scope));
                 }
             }
         }

--- a/crates/wesl/src/visit.rs
+++ b/crates/wesl/src/visit.rs
@@ -397,7 +397,8 @@ impl_visit! { GlobalDeclaration => ExpressionNode,
         },
         GlobalDeclaration::Function.{
             body.statements.[].(x => visit::<Statement, ExpressionNode>(x)),
-        }
+        },
+        GlobalDeclaration::Compound.body.[].(x => visit::<GlobalDeclaration, ExpressionNode>(x)),
     }
 }
 
@@ -439,6 +440,10 @@ impl_visit! { GlobalDeclaration => Attributes,
             body.{ attributes, statements.[].(x => visit::<Statement, Attributes>(x)) }
         },
         GlobalDeclaration::ConstAssert.attributes,
+        GlobalDeclaration::Compound.{
+            attributes,
+            body.[].(x => visit::<GlobalDeclaration, Attributes>(x))
+        }
     }
 }
 
@@ -454,7 +459,11 @@ impl_visit! { GlobalDeclaration => TypeExpression,
         GlobalDeclaration::TypeAlias.(x => visit::<TypeAlias, TypeExpression>(x)),
         GlobalDeclaration::Struct.(x => visit::<Struct, TypeExpression>(x)),
         GlobalDeclaration::Function.(x => visit::<Function, TypeExpression>(x)),
-        GlobalDeclaration::ConstAssert.(x => visit::<ConstAssert, TypeExpression>(x))
+        GlobalDeclaration::ConstAssert.(x => visit::<ConstAssert, TypeExpression>(x)),
+        GlobalDeclaration::Compound.{
+            attributes.[].(x => visit::<Attribute, TypeExpression>(x)),
+            body.[].(x => visit::<GlobalDeclaration, TypeExpression>(x))
+        }
     }
 }
 

--- a/crates/wgsl-parse/src/syntax.rs
+++ b/crates/wgsl-parse/src/syntax.rs
@@ -202,6 +202,8 @@ pub enum GlobalDeclaration {
     Struct(Struct),
     Function(Function),
     ConstAssert(ConstAssert),
+    #[cfg(feature = "condcomp")]
+    Compound(CompoundGlobalDeclaration),
 }
 
 pub type GlobalDeclarationNode = Spanned<GlobalDeclaration>;
@@ -286,6 +288,15 @@ pub struct ConstAssert {
     #[cfg(feature = "attributes")]
     pub attributes: Attributes,
     pub expression: ExpressionNode,
+}
+
+#[cfg(feature = "condcomp")]
+#[cfg_attr(feature = "tokrepr", derive(TokRepr))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq)]
+pub struct CompoundGlobalDeclaration {
+    pub attributes: Attributes,
+    pub body: Vec<GlobalDeclarationNode>,
 }
 
 #[cfg_attr(feature = "tokrepr", derive(TokRepr))]

--- a/crates/wgsl-parse/src/syntax.rs
+++ b/crates/wgsl-parse/src/syntax.rs
@@ -389,6 +389,14 @@ impl Attribute {
             _ => false,
         }
     }
+
+    #[cfg(feature = "condcomp")]
+    pub fn is_condcomp(&self) -> bool {
+        matches!(
+            self,
+            Attribute::If(_) | Attribute::Elif(_) | Attribute::Else
+        )
+    }
 }
 
 pub type AttributeNode = Spanned<Attribute>;

--- a/crates/wgsl-parse/src/syntax_display.rs
+++ b/crates/wgsl-parse/src/syntax_display.rs
@@ -167,6 +167,8 @@ impl Display for GlobalDeclaration {
             GlobalDeclaration::Struct(print) => write!(f, "{print}"),
             GlobalDeclaration::Function(print) => write!(f, "{print}"),
             GlobalDeclaration::ConstAssert(print) => write!(f, "{print}"),
+            #[cfg(feature = "condcomp")]
+            GlobalDeclaration::Compound(print) => write!(f, "{print}"),
         }
     }
 }
@@ -263,6 +265,15 @@ impl Display for ConstAssert {
         write!(f, "{}", fmt_attrs(&self.attributes, false))?;
         let expr = &self.expression;
         write!(f, "const_assert {expr};",)
+    }
+}
+
+#[cfg(feature = "condcomp")]
+impl Display for CompoundGlobalDeclaration {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", fmt_attrs(&self.attributes, false))?;
+        let stmts = Indent(self.body.iter().format("\n"));
+        write!(f, "{{\n{stmts}\n}}")
     }
 }
 

--- a/crates/wgsl-parse/src/syntax_impl.rs
+++ b/crates/wgsl-parse/src/syntax_impl.rs
@@ -651,6 +651,7 @@ impl SyntaxNode for GlobalDeclaration {
             GlobalDeclaration::Struct(decl) => Some(decl.ident.clone()),
             GlobalDeclaration::Function(decl) => Some(decl.ident.clone()),
             GlobalDeclaration::ConstAssert(_) => None,
+            GlobalDeclaration::Compound(_) => None,
         }
     }
 
@@ -661,6 +662,7 @@ impl SyntaxNode for GlobalDeclaration {
         GlobalDeclaration::Struct,
         GlobalDeclaration::Function,
         GlobalDeclaration::ConstAssert,
+        GlobalDeclaration::Compound,
     }
 }
 

--- a/crates/wgsl-parse/src/wgsl.lalrpop
+++ b/crates/wgsl-parse/src/wgsl.lalrpop
@@ -227,6 +227,8 @@ GlobalDecl: GlobalDeclaration = {
     <StructDecl>               => GlobalDeclaration::Struct(<>),
     <FunctionDecl>             => GlobalDeclaration::Function(<>),
     <ConstAssertStatement> ";" => GlobalDeclaration::ConstAssert(<>),
+    #[cfg(feature = "condcomp")]
+    <CompoundGlobalDecl> => GlobalDeclaration::Compound(<>),
 };
 
 GlobalDeclarationNode: GlobalDeclarationNode = Spanned<GlobalDecl>;
@@ -1203,6 +1205,13 @@ ParamList: Vec<FormalParameter> = {
 Param: FormalParameter = {
     <attributes: AttributeNode*> <ident: Ident> ":" <ty: TypeSpecifier> => FormalParameter {
         attributes, ident, ty
+    },
+};
+
+#[cfg(feature = "condcomp")]
+CompoundGlobalDecl: CompoundGlobalDeclaration = {
+    <attributes: AttributeNode*> "{" <body: GlobalDeclarationNode*> "}" => CompoundGlobalDeclaration {
+        attributes, body
     },
 };
 


### PR DESCRIPTION
This is a quick and easy fix for "there is too much repetition of conditionals". It's a dealbreaker for bevy.

* `@if` before a block just removes the block
* there can be top-level blocks with an `@if`.

Top-level blocks without `@if` are silently eliminated during compilation. A follow-up PR could make this an error. Flattened blocks can be nested, and get recursively flattened.

Related https://github.com/webgpu-tools/wesl-spec/issues/158

Discord discussion https://discord.com/channels/1275293995152703488/1275318205530898503/1533387407066660934
