### PR TITLE
Detect color support for diagnostics with anstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,6 +1516,7 @@ name = "wesl"
 version = "0.4.1"
 dependencies = [
  "annotate-snippets",
+ "anstream",
  "derive_more",
  "glob",
  "half",

--- a/crates/wesl-cli/src/main.rs
+++ b/crates/wesl-cli/src/main.rs
@@ -683,10 +683,7 @@ fn run(cli: Cli) -> Result<(), CliError> {
                 .scan_root(args.dir)
                 .expect("failed to scan WESL files")
                 .validate()
-                .map_err(|e| {
-                    eprintln!("{e}");
-                    panic!()
-                })
+                .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
                 .unwrap()
                 .codegen();
             println!("{code}");

--- a/crates/wesl-cli/src/main.rs
+++ b/crates/wesl-cli/src/main.rs
@@ -683,7 +683,7 @@ fn run(cli: Cli) -> Result<(), CliError> {
                 .scan_root(args.dir)
                 .expect("failed to scan WESL files")
                 .validate()
-                .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
+                .inspect_err(|e| eprintln!("{e}"))
                 .unwrap()
                 .codegen();
             println!("{code}");

--- a/crates/wesl/Cargo.toml
+++ b/crates/wesl/Cargo.toml
@@ -13,6 +13,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 annotate-snippets = "0.12.4"
+anstream = "1.0.0"
 derive_more = {
   version = "2.0.1",
   features = [

--- a/crates/wesl/README.md
+++ b/crates/wesl/README.md
@@ -19,7 +19,7 @@ let compiler = Wesl::new("src/shaders");
 // compile a WESL file to a WGSL string
 let wgsl_str = compiler
     .compile(&"package::main".parse().unwrap())
-    .inspect_err(|e| eprintln!("WESL error: {}", e.diagnostic().colored())) // pretty colored errors
+    .inspect_err(|e| eprintln!("WESL error: {e}")) // pretty-print error diagnostics
     .unwrap()
     .to_string();
 ```

--- a/crates/wesl/README.md
+++ b/crates/wesl/README.md
@@ -19,7 +19,7 @@ let compiler = Wesl::new("src/shaders");
 // compile a WESL file to a WGSL string
 let wgsl_str = compiler
     .compile(&"package::main".parse().unwrap())
-    .inspect_err(|e| eprintln!("WESL error: {e}")) // pretty errors with `display()`
+    .inspect_err(|e| eprintln!("WESL error: {}", e.diagnostic().colored())) // pretty colored errors
     .unwrap()
     .to_string();
 ```

--- a/crates/wesl/src/error.rs
+++ b/crates/wesl/src/error.rs
@@ -587,13 +587,13 @@ impl<E: std::error::Error> Diagnostic<E> {
         renderer.render(&[group])
     }
 
-    pub fn fmt_plain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt_plain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let renderer = annotate_snippets::Renderer::plain();
         let rendered = self.fmt_snippet(&renderer);
         write!(f, "{rendered}")
     }
 
-    pub fn fmt_colored(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt_colored(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let renderer = annotate_snippets::Renderer::styled();
         let rendered = self.fmt_snippet(&renderer);
         write!(f, "{rendered}")
@@ -604,25 +604,25 @@ impl<E: std::error::Error> std::error::Error for Diagnostic<E> {}
 
 impl<E: std::error::Error> Display for Diagnostic<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.fmt_plain(f)
+        if anstream::stdout().is_terminal() {
+            self.fmt_colored(f)
+        } else {
+            self.fmt_plain(f)
+        }
     }
 }
 
-/// Wrapper type that provides a colored output.
+/// Wrapper type that provides forces a colored/non-colored output.
 #[derive(Debug)]
-pub struct ColoredDiagnostic<'a, E>(&'a Diagnostic<E>);
+pub struct ColoredDiagnostic<'a, E>(&'a Diagnostic<E>, bool);
 
 impl<E> Diagnostic<E> {
-    /// A [`std::fmt::Display`] adapter to get a colored output when printing to stdout or stderr.
-    pub fn colored(&self) -> ColoredDiagnostic<'_, E> {
-        ColoredDiagnostic(self)
-    }
-}
-
-impl<E> ColoredDiagnostic<'_, E> {
-    /// Revert to a non-colored diagnostic.
-    pub fn plain(&self) -> &Diagnostic<E> {
-        self.0
+    /// A [`std::fmt::Display`] adapter to get a colored output (with ANSI codes).
+    ///
+    /// Diagnostics auto-detect if colors are supported using `anstream`.
+    /// With this adapter, you can force a colored or non-colored output.
+    pub fn colored(&self, colored: bool) -> ColoredDiagnostic<'_, E> {
+        ColoredDiagnostic(self, colored)
     }
 }
 
@@ -640,6 +640,10 @@ impl<E: std::error::Error> std::error::Error for ColoredDiagnostic<'_, E> {}
 
 impl<E: std::error::Error> std::fmt::Display for ColoredDiagnostic<'_, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt_colored(f)
+        if self.1 {
+            self.0.fmt_colored(f)
+        } else {
+            self.0.fmt_plain(f)
+        }
     }
 }

--- a/crates/wesl/src/error.rs
+++ b/crates/wesl/src/error.rs
@@ -543,7 +543,7 @@ impl Diagnostic<Error> {
 }
 
 impl<E: std::error::Error> Diagnostic<E> {
-    fn fmt_snippet(&self, renderer: &annotate_snippets::Renderer) -> String {
+    fn render_snippet(&self, renderer: &annotate_snippets::Renderer) -> String {
         use annotate_snippets::*;
         let msg = format!("{}", self.error);
         let title = Level::ERROR.primary_title(&msg);
@@ -587,16 +587,14 @@ impl<E: std::error::Error> Diagnostic<E> {
         renderer.render(&[group])
     }
 
-    fn fmt_plain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    pub fn render_plain(&self) -> String {
         let renderer = annotate_snippets::Renderer::plain();
-        let rendered = self.fmt_snippet(&renderer);
-        write!(f, "{rendered}")
+        self.render_snippet(&renderer)
     }
 
-    fn fmt_colored(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    pub fn render_colored(&self) -> String {
         let renderer = annotate_snippets::Renderer::styled();
-        let rendered = self.fmt_snippet(&renderer);
-        write!(f, "{rendered}")
+        self.render_snippet(&renderer)
     }
 }
 
@@ -604,10 +602,15 @@ impl<E: std::error::Error> std::error::Error for Diagnostic<E> {}
 
 impl<E: std::error::Error> Display for Diagnostic<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if anstream::stdout().is_terminal() {
-            self.fmt_colored(f)
+        // AutoStream::choice may return `AlwaysAnsi`, `Always` or `Never`.
+        // It never returns `Auto`.
+        // It checks terminal capabilities as well as env vars:
+        // `NO_COLOR`, `CLICOLOR`, `CLICOLOR_FORCE` and `CI`.
+        let choice = anstream::AutoStream::choice(&std::io::stdout());
+        if choice == anstream::ColorChoice::Always || choice == anstream::ColorChoice::AlwaysAnsi {
+            write!(f, "{}", self.render_colored())
         } else {
-            self.fmt_plain(f)
+            write!(f, "{}", self.render_plain())
         }
     }
 }
@@ -641,9 +644,9 @@ impl<E: std::error::Error> std::error::Error for ColoredDiagnostic<'_, E> {}
 impl<E: std::error::Error> std::fmt::Display for ColoredDiagnostic<'_, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.1 {
-            self.0.fmt_colored(f)
+            write!(f, "{}", self.0.render_colored())
         } else {
-            self.0.fmt_plain(f)
+            write!(f, "{}", self.0.render_plain())
         }
     }
 }

--- a/crates/wesl/src/error.rs
+++ b/crates/wesl/src/error.rs
@@ -46,7 +46,7 @@ pub enum Error {
 /// A diagnostic is a wrapper around an error with extra contextual metadata: the source,
 /// the declaration name, the span, ...
 #[derive(Clone, Debug)]
-pub struct Diagnostic<E: std::error::Error> {
+pub struct Diagnostic<E> {
     pub error: Box<E>,
     pub detail: Box<Detail>,
 }
@@ -542,10 +542,8 @@ impl Diagnostic<Error> {
     }
 }
 
-impl<E: std::error::Error> std::error::Error for Diagnostic<E> {}
-
-impl<E: std::error::Error> Display for Diagnostic<E> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<E: std::error::Error> Diagnostic<E> {
+    fn fmt_snippet(&self, renderer: &annotate_snippets::Renderer) -> String {
         use annotate_snippets::*;
         let msg = format!("{}", self.error);
         let title = Level::ERROR.primary_title(&msg);
@@ -586,8 +584,55 @@ impl<E: std::error::Error> Display for Diagnostic<E> {
         }
         let group = group.element(Level::NOTE.message(&note));
 
-        let renderer = Renderer::styled();
-        let rendered = renderer.render(&[group]);
+        renderer.render(&[group])
+    }
+
+    pub fn fmt_plain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let renderer = annotate_snippets::Renderer::plain();
+        let rendered = self.fmt_snippet(&renderer);
         write!(f, "{rendered}")
+    }
+
+    pub fn fmt_colored(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let renderer = annotate_snippets::Renderer::styled();
+        let rendered = self.fmt_snippet(&renderer);
+        write!(f, "{rendered}")
+    }
+}
+
+impl<E: std::error::Error> std::error::Error for Diagnostic<E> {}
+
+impl<E: std::error::Error> Display for Diagnostic<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.fmt_plain(f)
+    }
+}
+
+/// Wrapper type that provides a colored output.
+#[derive(Debug)]
+pub struct ColoredDiagnostic<'a, E>(&'a Diagnostic<E>);
+
+impl<E> Diagnostic<E> {
+    /// A [`std::fmt::Display`] adapter to get a colored output when printing to stdout or stderr.
+    pub fn colored(&self) -> ColoredDiagnostic<'_, E> {
+        ColoredDiagnostic(self)
+    }
+}
+
+impl Error {
+    /// Convert this error to a [`Diagnostic`].
+    ///
+    /// Diagnostics provide better-looking error messages.
+    /// Use [`Diagnostic::colored`] to get a colored output similar to Rust's compiler errors.
+    pub fn diagnostic(&self) -> Diagnostic<Error> {
+        Diagnostic::from(self.clone())
+    }
+}
+
+impl<E: std::error::Error> std::error::Error for ColoredDiagnostic<'_, E> {}
+
+impl<E: std::error::Error> std::fmt::Display for ColoredDiagnostic<'_, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt_colored(f)
     }
 }

--- a/crates/wesl/src/error.rs
+++ b/crates/wesl/src/error.rs
@@ -619,6 +619,13 @@ impl<E> Diagnostic<E> {
     }
 }
 
+impl<E> ColoredDiagnostic<'_, E> {
+    /// Revert to a non-colored diagnostic.
+    pub fn plain(&self) -> &Diagnostic<E> {
+        self.0
+    }
+}
+
 impl Error {
     /// Convert this error to a [`Diagnostic`].
     ///

--- a/crates/wesl/src/package.rs
+++ b/crates/wesl/src/package.rs
@@ -78,7 +78,7 @@ pub(crate) const RESERVED_MOD_NAMES: &[&str] = &[
 ///        .expect("failed to scan WESL files")
 ///        // validation is optional
 ///        .validate()
-///        .map_err(|e| eprintln!("{e}"))
+///        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
 ///        .expect("validation error")
 ///        // write "my_package.rs" in OUT_DIR
 ///        .build_artifact()

--- a/crates/wesl/src/package.rs
+++ b/crates/wesl/src/package.rs
@@ -78,7 +78,7 @@ pub(crate) const RESERVED_MOD_NAMES: &[&str] = &[
 ///        .expect("failed to scan WESL files")
 ///        // validation is optional
 ///        .validate()
-///        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
+///        .inspect_err(|e| eprintln!("{e}"))
 ///        .expect("validation error")
 ///        // write "my_package.rs" in OUT_DIR
 ///        .build_artifact()

--- a/examples/dependency-resolution/a/build.rs
+++ b/examples/dependency-resolution/a/build.rs
@@ -5,7 +5,7 @@ fn main() {
         .scan_root("src/main")
         .expect("failed to scan WESL files")
         .validate()
-        .map_err(|e| eprintln!("{e}"))
+        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
         .expect("validation error")
         .build_artifact()
         .expect("failed to build artifact");

--- a/examples/dependency-resolution/a/build.rs
+++ b/examples/dependency-resolution/a/build.rs
@@ -5,7 +5,7 @@ fn main() {
         .scan_root("src/main")
         .expect("failed to scan WESL files")
         .validate()
-        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
+        .inspect_err(|e| eprintln!("{e}"))
         .expect("validation error")
         .build_artifact()
         .expect("failed to build artifact");

--- a/examples/dependency-resolution/b/build.rs
+++ b/examples/dependency-resolution/b/build.rs
@@ -5,7 +5,7 @@ fn main() {
         .scan_root("src/main")
         .expect("failed to scan WESL files")
         .validate()
-        .map_err(|e| eprintln!("{e}"))
+        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
         .expect("validation error")
         .build_artifact()
         .expect("failed to build artifact");

--- a/examples/dependency-resolution/b/build.rs
+++ b/examples/dependency-resolution/b/build.rs
@@ -5,7 +5,7 @@ fn main() {
         .scan_root("src/main")
         .expect("failed to scan WESL files")
         .validate()
-        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
+        .inspect_err(|e| eprintln!("{e}"))
         .expect("validation error")
         .build_artifact()
         .expect("failed to build artifact");

--- a/examples/dependency-resolution/c1/build.rs
+++ b/examples/dependency-resolution/c1/build.rs
@@ -3,7 +3,7 @@ fn main() {
         .scan_root("src/main")
         .expect("failed to scan WESL files")
         .validate()
-        .map_err(|e| eprintln!("{e}"))
+        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
         .expect("validation error")
         .build_artifact()
         .expect("failed to build artifact");

--- a/examples/dependency-resolution/c1/build.rs
+++ b/examples/dependency-resolution/c1/build.rs
@@ -3,7 +3,7 @@ fn main() {
         .scan_root("src/main")
         .expect("failed to scan WESL files")
         .validate()
-        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
+        .inspect_err(|e| eprintln!("{e}"))
         .expect("validation error")
         .build_artifact()
         .expect("failed to build artifact");

--- a/examples/dependency-resolution/d1/build.rs
+++ b/examples/dependency-resolution/d1/build.rs
@@ -3,7 +3,7 @@ fn main() {
         .scan_root("src/main")
         .expect("failed to scan WESL files")
         .validate()
-        .map_err(|e| eprintln!("{e}"))
+        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
         .expect("validation error")
         .build_artifact()
         .expect("failed to build artifact");

--- a/examples/dependency-resolution/d1/build.rs
+++ b/examples/dependency-resolution/d1/build.rs
@@ -3,7 +3,7 @@ fn main() {
         .scan_root("src/main")
         .expect("failed to scan WESL files")
         .validate()
-        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
+        .inspect_err(|e| eprintln!("{e}"))
         .expect("validation error")
         .build_artifact()
         .expect("failed to build artifact");

--- a/examples/dependency-resolution/d2/build.rs
+++ b/examples/dependency-resolution/d2/build.rs
@@ -3,7 +3,7 @@ fn main() {
         .scan_root("src/main")
         .expect("failed to scan WESL files")
         .validate()
-        .map_err(|e| eprintln!("{e}"))
+        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
         .expect("validation error")
         .build_artifact()
         .expect("failed to build artifact");

--- a/examples/dependency-resolution/d2/build.rs
+++ b/examples/dependency-resolution/d2/build.rs
@@ -3,7 +3,7 @@ fn main() {
         .scan_root("src/main")
         .expect("failed to scan WESL files")
         .validate()
-        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
+        .inspect_err(|e| eprintln!("{e}"))
         .expect("validation error")
         .build_artifact()
         .expect("failed to build artifact");

--- a/examples/dependency-resolution/src/main.rs
+++ b/examples/dependency-resolution/src/main.rs
@@ -7,7 +7,7 @@ fn main() {
         .add_package(&a::a::PACKAGE)
         .add_package(&b::b::PACKAGE)
         .compile(&"package::main".parse().unwrap())
-        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
+        .inspect_err(|e| eprintln!("{e}"))
         .expect("compilation error")
         .to_string();
 

--- a/examples/dependency-resolution/src/main.rs
+++ b/examples/dependency-resolution/src/main.rs
@@ -7,7 +7,7 @@ fn main() {
         .add_package(&a::a::PACKAGE)
         .add_package(&b::b::PACKAGE)
         .compile(&"package::main".parse().unwrap())
-        .map_err(|e| eprintln!("{e}"))
+        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
         .expect("compilation error")
         .to_string();
 

--- a/examples/random_wgsl/build.rs
+++ b/examples/random_wgsl/build.rs
@@ -3,7 +3,7 @@ fn main() {
         .scan_root("src/shaders")
         .expect("failed to scan WESL files")
         .validate()
-        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
+        .inspect_err(|e| eprintln!("{e}"))
         .unwrap()
         .build_artifact()
         .expect("failed to build artifact")

--- a/examples/random_wgsl/build.rs
+++ b/examples/random_wgsl/build.rs
@@ -3,10 +3,7 @@ fn main() {
         .scan_root("src/shaders")
         .expect("failed to scan WESL files")
         .validate()
-        .inspect_err(|e| {
-            eprintln!("{e}");
-            panic!();
-        })
+        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
         .unwrap()
         .build_artifact()
         .expect("failed to build artifact")

--- a/examples/runtime_wesl/src/main.rs
+++ b/examples/runtime_wesl/src/main.rs
@@ -2,10 +2,7 @@ fn main() {
     let source = wesl::Wesl::new("src/shaders")
         .add_package(&random_wgsl::PACKAGE)
         .compile(&"package::main".parse().unwrap())
-        .inspect_err(|e| {
-            eprintln!("{e}");
-            panic!();
-        })
+        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
         .unwrap()
         .to_string();
 

--- a/examples/runtime_wesl/src/main.rs
+++ b/examples/runtime_wesl/src/main.rs
@@ -2,7 +2,7 @@ fn main() {
     let source = wesl::Wesl::new("src/shaders")
         .add_package(&random_wgsl::PACKAGE)
         .compile(&"package::main".parse().unwrap())
-        .inspect_err(|e| eprintln!("{}", e.diagnostic().colored()))
+        .inspect_err(|e| eprintln!("{e}"))
         .unwrap()
         .to_string();
 


### PR DESCRIPTION
The implementation of `Display` for diagnosics and errors was always colored using ANSI terminal codes. This can be undesirable in non-terminal environments. 

With this PR, diagnostics are colored if stdout is a terminal, according to `anstream`.

```rs
let err: Error = ...;
println!("{err}"); // prints with colors if anstream would print with colors
println!("{}", err.diagnostic().colored(false)); // force no colors
```